### PR TITLE
Add Docker support and shared repo transactions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,7 @@ debug/
 build/
 dist/
 *.egg-info/
+datarepos/
 
 # Node/npm cache if any
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,10 @@ RUN pip install --upgrade pip && \
 # Copy the rest of the source
 COPY . .
 
+# Convenience launcher so the image can be used for ad hoc CLI commands too.
+RUN printf '%s\n' '#!/bin/sh' 'exec python3 /app/sf.py "$@"' > /usr/local/bin/sf && \
+    chmod +x /usr/local/bin/sf
+
 # Bake version metadata file for runtime (if args provided)
 RUN set -e; \
     V_SHORT="${SF_APP_VERSION_SHORT}"; \
@@ -69,3 +73,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -fsS http://127.0.0.1:${PORT}/ || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]
+CMD ["web"]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,45 @@ http://127.0.0.1:8080
 # Commit messages include machine-readable tokens like ::sfid::<SFID>.
 ```
 
+## Docker
+
+smallFactory now supports a single-image Docker workflow for both the web app
+and ad hoc CLI usage against the same persisted data repo.
+
+Quick start with Compose:
+
+```sh
+docker compose up --build
+# Web UI: http://127.0.0.1:8080
+# MCP:    http://127.0.0.1:8080/mcp
+```
+
+Run CLI commands without attaching to the running container:
+
+```sh
+docker compose run --rm smallfactory inventory onhand --readonly
+docker compose run --rm smallfactory entities ls
+./scripts/sf-docker.sh inventory onhand --readonly
+```
+
+Plain Docker works too:
+
+```sh
+docker run --rm -it -p 8080:8080 -v smallfactory-data:/data smallfactory:local
+docker run --rm -it -v smallfactory-data:/data smallfactory:local repo validate
+```
+
+Container defaults:
+
+- Data root: `/data`
+- Data repo: `/data/datarepo`
+- Config: `/data/.smallfactory.yml`
+
+If `/data/datarepo` is empty, the container will clone `SF_REPO_GIT_URL` on
+first start, or initialize a fresh smallFactory repo if no Git URL is provided.
+
+See the full guide: [Docker guide](docs/users/docker.md)
+
 ## Community
 
 Join the smallFactory Discord:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,18 @@
+services:
+  smallfactory:
+    build:
+      context: .
+    image: smallfactory:local
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: "8080"
+      SF_DATA_PATH: /data
+      SF_REPO_PATH: /data/datarepo
+      SF_REPO_NAME: datarepo
+    volumes:
+      - smallfactory-data:/data
+    restart: unless-stopped
+
+volumes:
+  smallfactory-data:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,52 +14,57 @@ set -euo pipefail
 : "${SF_GIT_USER_NAME:=smallFactory Web}"
 : "${SF_GIT_USER_EMAIL:=web@smallfactory.local}"
 
-# Export author/committer for processes that run during init
+export SF_DATA_PATH
+export SF_REPO_PATH
+export SF_REPO_GIT_URL
+export SF_REPO_NAME
+export SF_CONFIG_DIR="${SF_DATA_PATH%/}"
+export SF_REPO="${SF_REPO_PATH}"
+export SF_DATAREPO="${SF_REPO_PATH}"
 export GIT_AUTHOR_NAME="$SF_GIT_USER_NAME"
 export GIT_AUTHOR_EMAIL="$SF_GIT_USER_EMAIL"
 export GIT_COMMITTER_NAME="$SF_GIT_USER_NAME"
 export GIT_COMMITTER_EMAIL="$SF_GIT_USER_EMAIL"
 
-# Ensure new repos default to 'main' branch (not 'master')
-if command -v git >/dev/null 2>&1; then
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+if [ -z "${SF_APP_PATH:-}" ]; then
+  if [ -d /app ]; then
+    SF_APP_PATH=/app
+  else
+    SF_APP_PATH="$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)"
+  fi
+fi
+export SF_APP_PATH
+cd "$SF_APP_PATH"
+
+ensure_config_file() {
+  local config_file
+  config_file="${SF_CONFIG_DIR}/.smallfactory.yml"
+
+  mkdir -p "$SF_CONFIG_DIR"
+  if [ ! -f "$config_file" ]; then
+    printf "default_datarepo: %s\n" "$SF_REPO_PATH" > "$config_file"
+    return
+  fi
+
+  if grep -q '^default_datarepo:' "$config_file"; then
+    sed -i "s#^default_datarepo:.*#default_datarepo: ${SF_REPO_PATH//#/\\#}#" "$config_file"
+  else
+    printf "default_datarepo: %s\n" "$SF_REPO_PATH" >> "$config_file"
+  fi
+}
+
+configure_git() {
+  if ! command -v git >/dev/null 2>&1; then
+    return
+  fi
+  if [ -n "${HOME:-}" ]; then
+    mkdir -p "$HOME" || true
+  fi
+
   git config --global init.defaultBranch main || true
-fi
-
-cd /app
-
-# Ensure .smallfactory.yml under the shared parent data path
-export SF_CONFIG_DIR="${SF_DATA_PATH%/}"
-CONFIG_FILE="$SF_CONFIG_DIR/.smallfactory.yml"
-mkdir -p "$SF_CONFIG_DIR"
-if [ ! -f "$CONFIG_FILE" ]; then
-  printf "default_datarepo: %s\n" "$SF_REPO_PATH" > "$CONFIG_FILE"
-else
-  # Idempotently set/update default_datarepo
-  if grep -q '^default_datarepo:' "$CONFIG_FILE"; then
-    sed -i "s#^default_datarepo:.*#default_datarepo: ${SF_REPO_PATH//#/\\#}#" "$CONFIG_FILE"
-  else
-    printf "default_datarepo: %s\n" "$SF_REPO_PATH" >> "$CONFIG_FILE"
-  fi
-fi
-
-# Prepare datarepo: clone if URL provided and directory empty; else init if empty
-mkdir -p "$SF_REPO_PATH"
-if [ -z "$(ls -A "$SF_REPO_PATH" 2>/dev/null)" ]; then
-  if [ -n "$SF_REPO_GIT_URL" ]; then
-    echo "[entrypoint] Cloning datarepo from $SF_REPO_GIT_URL -> $SF_REPO_PATH"
-    git clone --depth 1 "$SF_REPO_GIT_URL" "$SF_REPO_PATH"
-  else
-    echo "[entrypoint] Initializing new datarepo at $SF_REPO_PATH"
-    python3 sf.py init "$SF_REPO_PATH" --name "$SF_REPO_NAME" || true
-  fi
-else
-  echo "[entrypoint] Using existing datarepo at $SF_REPO_PATH"
-fi
-
-# Optional: configure git safe.directory for mounted volume
-if command -v git >/dev/null 2>&1; then
   git config --global --add safe.directory "$SF_REPO_PATH" || true
-  # Ensure local repo has a user.name/user.email if not already set
+
   if [ -d "$SF_REPO_PATH/.git" ]; then
     if ! git -C "$SF_REPO_PATH" config --get user.name >/dev/null 2>&1; then
       git -C "$SF_REPO_PATH" config user.name "$SF_GIT_USER_NAME" || true
@@ -68,19 +73,129 @@ if command -v git >/dev/null 2>&1; then
       git -C "$SF_REPO_PATH" config user.email "$SF_GIT_USER_EMAIL" || true
     fi
   fi
+}
+
+bootstrap_repo() {
+  local bootstrap_lock
+  ensure_config_file
+  mkdir -p "$SF_REPO_PATH"
+  bootstrap_lock="${SF_CONFIG_DIR}/.smallfactory.bootstrap.lock"
+
+  while ! mkdir "$bootstrap_lock" 2>/dev/null; do
+    sleep 0.1
+  done
+  trap 'rmdir "$bootstrap_lock" >/dev/null 2>&1 || true' EXIT
+
+  mkdir -p "$SF_REPO_PATH"
+
+  if [ -z "$(ls -A "$SF_REPO_PATH" 2>/dev/null)" ]; then
+    if command -v git >/dev/null 2>&1; then
+      git config --global init.defaultBranch main || true
+    fi
+    if [ -n "$SF_REPO_GIT_URL" ]; then
+      echo "[entrypoint] Cloning datarepo from $SF_REPO_GIT_URL -> $SF_REPO_PATH"
+      git clone --depth 1 "$SF_REPO_GIT_URL" "$SF_REPO_PATH"
+    else
+      echo "[entrypoint] Initializing new datarepo at $SF_REPO_PATH"
+      python3 - <<'PY'
+from pathlib import Path
+import os
+from smallfactory.core.v1 import repo as repo_ops
+
+repo_path = Path(os.environ["SF_REPO_PATH"]).expanduser().resolve()
+repo_name = (os.environ.get("SF_REPO_NAME") or "datarepo").strip() or "datarepo"
+
+repo_ops.create_or_clone(repo_path, None)
+repo_ops.write_datarepo_config(repo_path)
+repo_ops.set_default_datarepo(repo_path)
+repo_ops.initial_commit_and_optional_push(repo_path, has_remote=False)
+repo_ops.scaffold_default_location(repo_path, "l_inbox")
+PY
+    fi
+  else
+    echo "[entrypoint] Using existing datarepo at $SF_REPO_PATH"
+  fi
+
+  rmdir "$bootstrap_lock" >/dev/null 2>&1 || true
+  trap - EXIT
+  configure_git
+}
+
+run_sf() {
+  exec python3 sf.py "$@"
+}
+
+run_web() {
+  exec python3 sf.py web --host 0.0.0.0 --port "$PORT" "$@"
+}
+
+needs_bootstrap() {
+  case "${1:-}" in
+    "")
+      return 0
+      ;;
+    cli|sf)
+      case "${2:-}" in
+        ""|-h|--help|help|--version|init)
+          return 1
+        ;;
+        *)
+          return 0
+          ;;
+      esac
+      ;;
+    web|repo|inventory|entities|bom|stickers)
+      case "${2:-}" in
+        -h|--help|help|--version)
+          return 1
+          ;;
+        *)
+          return 0
+          ;;
+      esac
+      ;;
+    init|-h|--help|help|--version)
+      return 1
+      ;;
+    bash|sh|/bin/bash|/bin/sh)
+      return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if needs_bootstrap "${1:-}" "${2:-}"; then
+  bootstrap_repo
 fi
 
-# Run the web server
-if [ -n "${SF_WEB_DEBUG:-}" ]; then
-  # Debug mode: use Flask's development server with auto-reload
-  exec python3 sf.py web --host 0.0.0.0 --port "$PORT" --debug
-else
-  # Production: use Gunicorn (threaded workers configurable via env)
-  exec gunicorn \
-    -w ${WEB_CONCURRENCY:-2} \
-    -k gthread \
-    --threads ${WEB_THREADS:-4} \
-    --timeout ${WEB_TIMEOUT:-120} \
-    --bind 0.0.0.0:"$PORT" \
-    web.app:app
-fi
+case "${1:-}" in
+  "")
+    run_web
+    ;;
+  web)
+    shift
+    run_web "$@"
+    ;;
+  cli)
+    shift
+    run_sf "$@"
+    ;;
+  sf)
+    shift
+    run_sf "$@"
+    ;;
+  repo|inventory|entities|bom|stickers)
+    run_sf "$@"
+    ;;
+  init|-h|--help|help|--version)
+    run_sf "$@"
+    ;;
+  bash|sh|/bin/bash|/bin/sh)
+    exec "$@"
+    ;;
+  *)
+    exec "$@"
+    ;;
+esac

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Welcome to the smallFactory documentation.
 - [Start Here](START_HERE.md)
 - [Web UI guide](../web/README.md)
 - [CLI basics](cli/README.md)
+- [Docker guide](users/docker.md)
 - [MCP integration](users/mcp.md)
 
 ## Developers

--- a/docs/users/README.md
+++ b/docs/users/README.md
@@ -5,5 +5,6 @@ Start with the non‑technical overview, then pick the UI or CLI as needed.
 - Start Here (overview): ../START_HERE.md
 - Web UI guide: ../../web/README.md
 - CLI basics: ../cli/README.md
+- Docker guide: docker.md
 - MCP integration: mcp.md
 - Build events: events.md

--- a/docs/users/docker.md
+++ b/docs/users/docker.md
@@ -1,0 +1,185 @@
+# Docker Guide
+
+smallFactory can run cleanly in Docker, but it behaves best when you treat the
+container as the runtime for both the web app and the CLI against the same
+mounted data repository.
+
+## What runs well in Docker
+
+- Web UI on port `8080`
+- MCP endpoint on `/mcp`
+- CLI commands against the same persisted repo
+- Git-backed writes and local commits
+- Sticker PDF generation and file uploads/downloads
+- Metrics endpoint on `/metrics`
+
+## Important Docker nuances
+
+- smallFactory is Git-native. The data repo must live on a persistent volume.
+- The web app, CLI, and MCP should all point at the same mounted repo.
+- `localhost` inside the container is the container, not your host machine.
+  This matters for Ollama and other local services.
+- Git push credentials do not automatically follow you into the container.
+  Local commits work out of the box; remote push usually needs extra setup.
+- Advisory file locks are used for repo and journal mutations. Prefer a local
+  Docker volume or a local-disk bind mount over a network filesystem.
+
+## Quick Start With Docker Compose
+
+Build and start the web UI:
+
+```bash
+docker compose up --build
+```
+
+Then open:
+
+- Web UI: `http://127.0.0.1:8080`
+- MCP: `http://127.0.0.1:8080/mcp`
+
+The included [compose.yaml](../../compose.yaml) stores data in the named volume
+`smallfactory-data`.
+
+## Easy CLI Usage Without Entering The Running Container
+
+Run ad hoc CLI commands against the same persisted volume:
+
+```bash
+docker compose run --rm smallfactory inventory onhand --readonly
+docker compose run --rm smallfactory entities ls
+docker compose run --rm smallfactory repo validate
+```
+
+There is also a thin wrapper in this repo:
+
+```bash
+./scripts/sf-docker.sh inventory onhand --readonly
+./scripts/sf-docker.sh entities ls
+```
+
+You can do the same with plain Docker:
+
+```bash
+docker run --rm -it -p 8080:8080 -v smallfactory-data:/data smallfactory:local
+docker run --rm -it -v smallfactory-data:/data smallfactory:local inventory onhand --readonly
+```
+
+The image accepts direct smallFactory commands, so you do not need
+`docker exec ... bash` for normal CLI usage.
+
+## Local Product Testing Workflow
+
+Yes, this can be a clean workflow even when the user is working on their host
+machine outside the container.
+
+Typical pattern:
+
+1. Keep the web app running in Docker.
+2. From the host shell, run ad hoc CLI commands with `docker compose run --rm`
+   or `./scripts/sf-docker.sh`.
+3. If you need host files such as test logs, firmware artifacts, or photos,
+   mount an extra host path into the one-off CLI container and reference that
+   mounted path.
+
+Example:
+
+```bash
+docker run --rm -it \
+  -v smallfactory-data:/data \
+  -v "$PWD:/work" \
+  smallfactory:local \
+  entities files add p_widget /work/test-output/log.txt logs/test-output.txt
+```
+
+That keeps SmallFactory's repo state in Docker while still letting the user work
+from the host machine where the physical-product tooling is actually running.
+
+## Existing Repo Or First-Time Repo
+
+By default the container uses:
+
+- config: `/data/.smallfactory.yml`
+- repo: `/data/datarepo`
+
+If `/data/datarepo` is empty:
+
+- `SF_REPO_GIT_URL` clones a repo into that path on first start
+- otherwise smallFactory initializes a fresh repo there
+
+Examples:
+
+```bash
+docker run --rm -it \
+  -p 8080:8080 \
+  -e SF_REPO_GIT_URL=https://github.com/you/your-datarepo.git \
+  -v smallfactory-data:/data \
+  smallfactory:local
+```
+
+If your repo should live at a different path, mount its parent and set
+`SF_REPO_PATH` accordingly.
+
+## Bind Mounts And Permissions
+
+Named volumes are the least fragile option.
+
+If you prefer a host bind mount, the main risk is file ownership mismatch
+between the host directory and the container user. On Linux, a common pattern is:
+
+```bash
+docker run --rm -it \
+  --user "$(id -u):$(id -g)" \
+  -p 8080:8080 \
+  -v "$PWD/docker-data:/data" \
+  smallfactory:local
+```
+
+## MCP In Docker
+
+The container starts smallFactory through `sf web`, so MCP is available on the
+same port as the web UI:
+
+- `http://127.0.0.1:8080/mcp`
+
+That matches the local non-Docker behavior and keeps docs/client setup the same.
+
+## Vision / Ollama In Docker
+
+The default Ollama URL is `http://localhost:11434`, which usually does not work
+from inside a container unless Ollama is running in the same container.
+
+Typical host-machine setup:
+
+```bash
+docker run --rm -it \
+  -p 8080:8080 \
+  -e SF_VISION_PROVIDER=ollama \
+  -e SF_OLLAMA_BASE_URL=http://host.docker.internal:11434 \
+  -v smallfactory-data:/data \
+  smallfactory:local
+```
+
+On Linux, you may also need:
+
+```bash
+--add-host=host.docker.internal:host-gateway
+```
+
+If you use OpenRouter instead, pass `SF_OPENROUTER_API_KEY` and related env vars
+as normal.
+
+## Git Pushes From Docker
+
+Local commits work with the repo inside the mounted volume.
+
+Remote pushes are the part that needs care:
+
+- HTTPS remotes usually need a token or credential helper in the container
+- SSH remotes usually need mounted keys or forwarded agent access
+- If you do not need container-side pushes, local commits still preserve history
+
+For many teams, the simplest first Docker setup is:
+
+- keep local commits enabled
+- leave push credentials out of the container initially
+- add credentials only when remote push from the web app is required

--- a/scripts/sf-docker.sh
+++ b/scripts/sf-docker.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+
+cd "$ROOT_DIR"
+exec docker compose run --rm smallfactory "$@"

--- a/smallfactory/cli/sf_cli.py
+++ b/smallfactory/cli/sf_cli.py
@@ -23,6 +23,7 @@ from smallfactory.core.v1.inventory import (
     inventory_onhand_readonly,
     inventory_rebuild,
 )
+from smallfactory.core.v1.transactions import run_repo_mutation
 
 # Entities core API
 from smallfactory.core.v1.entities import (
@@ -489,6 +490,9 @@ def main():
     def _fmt() -> str:
         return args.format
 
+    def _run_cli_repo_mutation(datarepo_path: pathlib.Path, mutate_fn):
+        return run_repo_mutation(datarepo_path, mutate_fn)
+
     def cmd_init(args):
         # Prefer GitHub clone; prompt for URL first if not provided
         github_url = (getattr(args, "github_url", None) or "").strip() or None
@@ -821,12 +825,15 @@ def main():
     def cmd_inventory_post(args):
         datarepo_path = _repo_path()
         try:
-            res = inventory_post(
+            res = _run_cli_repo_mutation(
                 datarepo_path,
-                part=args.part,
-                qty_delta=args.qty_delta,
-                l_sfid=getattr(args, "l_sfid", None),
-                reason=getattr(args, "reason", None),
+                lambda: inventory_post(
+                    datarepo_path,
+                    part=args.part,
+                    qty_delta=args.qty_delta,
+                    l_sfid=getattr(args, "l_sfid", None),
+                    reason=getattr(args, "reason", None),
+                ),
             )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
@@ -849,10 +856,13 @@ def main():
                     location=getattr(args, "l_sfid", None),
                 )
             else:
-                res = inventory_onhand(
+                res = _run_cli_repo_mutation(
                     datarepo_path,
-                    part=getattr(args, "part", None),
-                    location=getattr(args, "l_sfid", None),
+                    lambda: inventory_onhand(
+                        datarepo_path,
+                        part=getattr(args, "part", None),
+                        location=getattr(args, "l_sfid", None),
+                    ),
                 )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
@@ -869,7 +879,7 @@ def main():
     def cmd_inventory_rebuild(args):
         datarepo_path = _repo_path()
         try:
-            res = inventory_rebuild(datarepo_path)
+            res = _run_cli_repo_mutation(datarepo_path, lambda: inventory_rebuild(datarepo_path))
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -898,7 +908,10 @@ def main():
         datarepo_path = _repo_path()
         fields = _parse_pairs(getattr(args, "pairs", []))
         try:
-            ent = ent_create_entity(datarepo_path, args.sfid, fields or None)
+            ent = _run_cli_repo_mutation(
+                datarepo_path,
+                lambda: ent_create_entity(datarepo_path, args.sfid, fields or None),
+            )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -952,7 +965,10 @@ def main():
             print("[smallFactory] Error: no key=value pairs provided")
             sys.exit(2)
         try:
-            ent = ent_update_entity_fields(datarepo_path, args.sfid, updates)
+            ent = _run_cli_repo_mutation(
+                datarepo_path,
+                lambda: ent_update_entity_fields(datarepo_path, args.sfid, updates),
+            )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -968,7 +984,10 @@ def main():
     def cmd_entities_build_serial(args):
         datarepo_path = _repo_path()
         try:
-            ent = ent_update_entity_fields(datarepo_path, args.sfid, {"serialnumber": args.value})
+            ent = _run_cli_repo_mutation(
+                datarepo_path,
+                lambda: ent_update_entity_fields(datarepo_path, args.sfid, {"serialnumber": args.value}),
+            )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -991,7 +1010,10 @@ def main():
             print("[smallFactory] Error: invalid ISO 8601 datetime. Examples: 2024-06-01T12:00:00Z or 2024-06-01T12:00:00+00:00")
             sys.exit(2)
         try:
-            ent = ent_update_entity_fields(datarepo_path, args.sfid, {"datetime": val})
+            ent = _run_cli_repo_mutation(
+                datarepo_path,
+                lambda: ent_update_entity_fields(datarepo_path, args.sfid, {"datetime": val}),
+            )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -1006,7 +1028,10 @@ def main():
     def cmd_entities_retire(args):
         datarepo_path = _repo_path()
         try:
-            ent = ent_retire_entity(datarepo_path, args.sfid, reason=getattr(args, "reason", None))
+            ent = _run_cli_repo_mutation(
+                datarepo_path,
+                lambda: ent_retire_entity(datarepo_path, args.sfid, reason=getattr(args, "reason", None)),
+            )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -1063,7 +1088,10 @@ def main():
     def cmd_entities_files_mkdir(args):
         datarepo_path = _repo_path()
         try:
-            res = f_mkdir(datarepo_path, args.sfid, path=args.path)
+            res = _run_cli_repo_mutation(
+                datarepo_path,
+                lambda: f_mkdir(datarepo_path, args.sfid, path=args.path),
+            )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -1073,7 +1101,10 @@ def main():
     def cmd_entities_files_rmdir(args):
         datarepo_path = _repo_path()
         try:
-            res = f_rmdir(datarepo_path, args.sfid, path=args.path)
+            res = _run_cli_repo_mutation(
+                datarepo_path,
+                lambda: f_rmdir(datarepo_path, args.sfid, path=args.path),
+            )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -1088,12 +1119,15 @@ def main():
             sys.exit(2)
         b = src.read_bytes()
         try:
-            res = f_upload_file(
+            res = _run_cli_repo_mutation(
                 datarepo_path,
-                args.sfid,
-                path=args.dst,
-                file_bytes=b,
-                overwrite=bool(getattr(args, "overwrite", False)),
+                lambda: f_upload_file(
+                    datarepo_path,
+                    args.sfid,
+                    path=args.dst,
+                    file_bytes=b,
+                    overwrite=bool(getattr(args, "overwrite", False)),
+                ),
             )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
@@ -1104,7 +1138,10 @@ def main():
     def cmd_entities_files_rm(args):
         datarepo_path = _repo_path()
         try:
-            res = f_delete_file(datarepo_path, args.sfid, path=args.path)
+            res = _run_cli_repo_mutation(
+                datarepo_path,
+                lambda: f_delete_file(datarepo_path, args.sfid, path=args.path),
+            )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -1114,22 +1151,23 @@ def main():
     def cmd_entities_files_mv(args):
         datarepo_path = _repo_path()
         try:
-            if bool(getattr(args, "dir", False)):
-                res = f_move_dir(
+            def _mutate():
+                if bool(getattr(args, "dir", False)):
+                    return f_move_dir(
+                        datarepo_path,
+                        args.sfid,
+                        src=args.src,
+                        dst=args.dst,
+                        overwrite=bool(getattr(args, "overwrite", False)),
+                    )
+                return f_move_file(
                     datarepo_path,
                     args.sfid,
                     src=args.src,
                     dst=args.dst,
                     overwrite=bool(getattr(args, "overwrite", False)),
                 )
-            else:
-                res = f_move_file(
-                    datarepo_path,
-                    args.sfid,
-                    src=args.src,
-                    dst=args.dst,
-                    overwrite=bool(getattr(args, "overwrite", False)),
-                )
+            res = _run_cli_repo_mutation(datarepo_path, _mutate)
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -1166,82 +1204,74 @@ def main():
         tags = _parse_csv_tags(getattr(args, "tags", None))
         if tags is not None:
             event["tags"] = tags
-        try:
-            ent = ent_get_entity(datarepo_path, args.sfid)
-        except Exception as e:
-            print(f"[smallFactory] Error: {e}")
-            sys.exit(1)
         if not str(args.sfid).startswith("b_"):
             print("[smallFactory] Error: Build events are only supported for build entities ('b_*')")
             sys.exit(1)
         files = getattr(args, "files", None)
         file_links = [str(p).strip() for p in (files or []) if str(p).strip()]
         uploads = getattr(args, "uploads", None) or []
-        if uploads:
-            ev_id = str(event.get("id") or "").strip()
-            if not ev_id:
-                ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d%H%M%S")
-                base = f"evt_{ts}"
-                existing_ids = set()
-                try:
-                    existing_events = ent.get("events")
-                    if isinstance(existing_events, list):
-                        for ev in existing_events:
-                            if not isinstance(ev, dict):
-                                continue
-                            ex_id = str(ev.get("id") or "").strip()
-                            if ex_id:
-                                existing_ids.add(ex_id)
-                except Exception:
-                    pass
-                ev_id = base
-                i = 1
-                while ev_id in existing_ids:
-                    ev_id = f"{base}_{i}"
-                    i += 1
-                event["id"] = ev_id
-            seen_names = set()
-            for up in uploads:
-                src = pathlib.Path(str(up)).expanduser()
-                if not src.exists() or not src.is_file():
-                    print(f"[smallFactory] Error: upload source file not found: {src}")
-                    sys.exit(2)
-                name = src.name
-                stem = src.stem
-                suf = src.suffix
-                cand = name
-                i = 1
-                while cand in seen_names:
-                    cand = f"{stem}_{i}{suf}"
-                    i += 1
-                seen_names.add(cand)
-                dst = f"event_attachments/{ev_id}/{cand}"
-                try:
-                    up_res = f_upload_file(
-                        datarepo_path,
-                        args.sfid,
-                        path=dst,
-                        file_bytes=src.read_bytes(),
-                        overwrite=False,
-                    )
-                except Exception as e:
-                    print(f"[smallFactory] Error: {e}")
-                    sys.exit(1)
-                file_links.append(up_res.get("path") or dst)
-        if file_links:
-            dedup = []
-            seen = set()
-            for p in file_links:
-                if p in seen:
-                    continue
-                seen.add(p)
-                dedup.append(p)
-            event["files"] = dedup
-        if not event:
+        if not event and not file_links and not uploads:
             print("[smallFactory] Error: no event fields provided (use --message/--tags/--file/--upload)")
             sys.exit(2)
         try:
-            res = ent_append_build_event(datarepo_path, args.sfid, event)
+            def _mutate():
+                ent = ent_get_entity(datarepo_path, args.sfid)
+                local_event = dict(event)
+                local_file_links = list(file_links)
+                if uploads:
+                    ev_id = str(local_event.get("id") or "").strip()
+                    if not ev_id:
+                        ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d%H%M%S")
+                        base = f"evt_{ts}"
+                        existing_ids = set()
+                        existing_events = ent.get("events")
+                        if isinstance(existing_events, list):
+                            for ev in existing_events:
+                                if not isinstance(ev, dict):
+                                    continue
+                                ex_id = str(ev.get("id") or "").strip()
+                                if ex_id:
+                                    existing_ids.add(ex_id)
+                        ev_id = base
+                        i = 1
+                        while ev_id in existing_ids:
+                            ev_id = f"{base}_{i}"
+                            i += 1
+                        local_event["id"] = ev_id
+                    seen_names = set()
+                    for up in uploads:
+                        src = pathlib.Path(str(up)).expanduser()
+                        if not src.exists() or not src.is_file():
+                            raise FileNotFoundError(f"upload source file not found: {src}")
+                        name = src.name
+                        stem = src.stem
+                        suf = src.suffix
+                        cand = name
+                        i = 1
+                        while cand in seen_names:
+                            cand = f"{stem}_{i}{suf}"
+                            i += 1
+                        seen_names.add(cand)
+                        dst = f"event_attachments/{ev_id}/{cand}"
+                        up_res = f_upload_file(
+                            datarepo_path,
+                            args.sfid,
+                            path=dst,
+                            file_bytes=src.read_bytes(),
+                            overwrite=False,
+                        )
+                        local_file_links.append(up_res.get("path") or dst)
+                if local_file_links:
+                    dedup = []
+                    seen = set()
+                    for p in local_file_links:
+                        if p in seen:
+                            continue
+                        seen.add(p)
+                        dedup.append(p)
+                    local_event["files"] = dedup
+                return ent_append_build_event(datarepo_path, args.sfid, local_event)
+            res = _run_cli_repo_mutation(datarepo_path, _mutate)
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -1259,7 +1289,10 @@ def main():
             print("[smallFactory] Error: no updates provided (use --message and/or --tags)")
             sys.exit(2)
         try:
-            res = ent_update_build_event(datarepo_path, args.sfid, args.event_id, event)
+            res = _run_cli_repo_mutation(
+                datarepo_path,
+                lambda: ent_update_build_event(datarepo_path, args.sfid, args.event_id, event),
+            )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -1271,7 +1304,10 @@ def main():
         if tags is None:
             tags = []
         try:
-            res = ent_update_build_event_tags(datarepo_path, args.sfid, args.event_id, tags)
+            res = _run_cli_repo_mutation(
+                datarepo_path,
+                lambda: ent_update_build_event_tags(datarepo_path, args.sfid, args.event_id, tags),
+            )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -1280,7 +1316,10 @@ def main():
     def cmd_entities_events_link_file(args):
         datarepo_path = _repo_path()
         try:
-            res = ent_add_build_event_file_link(datarepo_path, args.sfid, args.event_id, args.path)
+            res = _run_cli_repo_mutation(
+                datarepo_path,
+                lambda: ent_add_build_event_file_link(datarepo_path, args.sfid, args.event_id, args.path),
+            )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -1291,23 +1330,24 @@ def main():
     def cmd_entities_rev_bump(args):
         datarepo_path = _repo_path()
         try:
-            # Cut next snapshot (draft), then immediately release it
-            res_bump = ent_bump_revision(
-                datarepo_path,
-                args.sfid,
-                rev=getattr(args, "rev", None),
-                notes=getattr(args, "notes", None),
-            )
-            new_rev = res_bump.get("new_rev")
-            if not new_rev:
-                raise RuntimeError("failed to determine new revision label")
-            res = ent_release_revision(
-                datarepo_path,
-                args.sfid,
-                new_rev,
-                released_at=getattr(args, "released_at", None),
-                notes=getattr(args, "notes", None),
-            )
+            def _mutate():
+                res_bump = ent_bump_revision(
+                    datarepo_path,
+                    args.sfid,
+                    rev=getattr(args, "rev", None),
+                    notes=getattr(args, "notes", None),
+                )
+                new_rev = res_bump.get("new_rev")
+                if not new_rev:
+                    raise RuntimeError("failed to determine new revision label")
+                return ent_release_revision(
+                    datarepo_path,
+                    args.sfid,
+                    new_rev,
+                    released_at=getattr(args, "released_at", None),
+                    notes=getattr(args, "notes", None),
+                )
+            res = _run_cli_repo_mutation(datarepo_path, _mutate)
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
             sys.exit(1)
@@ -1322,11 +1362,14 @@ def main():
     def cmd_entities_rev_new(args):
         datarepo_path = _repo_path()
         try:
-            res = ent_cut_revision(
+            res = _run_cli_repo_mutation(
                 datarepo_path,
-                args.sfid,
-                args.rev,
-                notes=getattr(args, "notes", None),
+                lambda: ent_cut_revision(
+                    datarepo_path,
+                    args.sfid,
+                    args.rev,
+                    notes=getattr(args, "notes", None),
+                ),
             )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
@@ -1342,12 +1385,15 @@ def main():
     def cmd_entities_rev_release(args):
         datarepo_path = _repo_path()
         try:
-            res = ent_release_revision(
+            res = _run_cli_repo_mutation(
                 datarepo_path,
-                args.sfid,
-                args.rev,
-                released_at=getattr(args, "released_at", None),
-                notes=getattr(args, "notes", None),
+                lambda: ent_release_revision(
+                    datarepo_path,
+                    args.sfid,
+                    args.rev,
+                    released_at=getattr(args, "released_at", None),
+                    notes=getattr(args, "notes", None),
+                ),
             )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
@@ -1420,16 +1466,19 @@ def main():
         if args.alts:
             alts = [{"use": a} for a in args.alts]
         try:
-            res = ent_bom_add_line(
+            res = _run_cli_repo_mutation(
                 datarepo_path,
-                args.parent,
-                use=args.use,
-                qty=args.qty,
-                rev=args.rev,
-                alternates=alts,
-                alternates_group=getattr(args, "alternates_group", None),
-                index=args.index,
-                check_exists=getattr(args, "check_exists", True),
+                lambda: ent_bom_add_line(
+                    datarepo_path,
+                    args.parent,
+                    use=args.use,
+                    qty=args.qty,
+                    rev=args.rev,
+                    alternates=alts,
+                    alternates_group=getattr(args, "alternates_group", None),
+                    index=args.index,
+                    check_exists=getattr(args, "check_exists", True),
+                ),
             )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
@@ -1445,12 +1494,15 @@ def main():
     def cmd_bom_rm(args):
         datarepo_path = _repo_path()
         try:
-            res = ent_bom_remove_line(
+            res = _run_cli_repo_mutation(
                 datarepo_path,
-                args.parent,
-                index=getattr(args, "index", None),
-                use=getattr(args, "use", None),
-                remove_all=getattr(args, "remove_all", False),
+                lambda: ent_bom_remove_line(
+                    datarepo_path,
+                    args.parent,
+                    index=getattr(args, "index", None),
+                    use=getattr(args, "use", None),
+                    remove_all=getattr(args, "remove_all", False),
+                ),
             )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
@@ -1475,12 +1527,15 @@ def main():
             print("[smallFactory] Error: no fields to update (--use/--qty/--rev/--alternates-group)")
             sys.exit(2)
         try:
-            res = ent_bom_set_line(
+            res = _run_cli_repo_mutation(
                 datarepo_path,
-                args.parent,
-                index=args.index,
-                updates=updates,
-                check_exists=getattr(args, "check_exists", True),
+                lambda: ent_bom_set_line(
+                    datarepo_path,
+                    args.parent,
+                    index=args.index,
+                    updates=updates,
+                    check_exists=getattr(args, "check_exists", True),
+                ),
             )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
@@ -1497,12 +1552,15 @@ def main():
     def cmd_bom_alt_add(args):
         datarepo_path = _repo_path()
         try:
-            res = ent_bom_alt_add(
+            res = _run_cli_repo_mutation(
                 datarepo_path,
-                args.parent,
-                index=args.index,
-                alt_use=args.alt_use,
-                check_exists=getattr(args, "check_exists", True),
+                lambda: ent_bom_alt_add(
+                    datarepo_path,
+                    args.parent,
+                    index=args.index,
+                    alt_use=args.alt_use,
+                    check_exists=getattr(args, "check_exists", True),
+                ),
             )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
@@ -1518,12 +1576,15 @@ def main():
     def cmd_bom_alt_rm(args):
         datarepo_path = _repo_path()
         try:
-            res = ent_bom_alt_remove(
+            res = _run_cli_repo_mutation(
                 datarepo_path,
-                args.parent,
-                index=args.index,
-                alt_index=getattr(args, "alt_index", None),
-                alt_use=getattr(args, "alt_use", None),
+                lambda: ent_bom_alt_remove(
+                    datarepo_path,
+                    args.parent,
+                    index=args.index,
+                    alt_index=getattr(args, "alt_index", None),
+                    alt_use=getattr(args, "alt_use", None),
+                ),
             )
         except Exception as e:
             print(f"[smallFactory] Error: {e}")
@@ -1677,7 +1738,9 @@ def main():
         ("inventory", "rebuild"): cmd_inventory_rebuild,
         ("entities", "add"): cmd_entities_add,
         ("entities", "ls"): cmd_entities_list,
+        ("entities", "list"): cmd_entities_list,
         ("entities", "show"): cmd_entities_show,
+        ("entities", "view"): cmd_entities_show,
         ("entities", "set"): cmd_entities_set,
         ("entities", "retire"): cmd_entities_retire,
         ("entities", "revision:bump"): cmd_entities_rev_bump,

--- a/smallfactory/core/v1/transactions.py
+++ b/smallfactory/core/v1/transactions.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Any, Callable, ContextManager, TypeVar
+import threading
+
+from .locks import assert_no_upgrade_in_progress, repo_process_lock
+from .versioning import assert_repo_version_matches_tool
+
+
+T = TypeVar("T")
+
+
+_REPO_TXN_LOCK = threading.Lock()
+
+
+def run_repo_mutation(
+    datarepo_path: Path,
+    mutate_fn: Callable[[], T],
+    *,
+    lock_timeout_seconds: float = 30.0,
+    lock_poll_interval_seconds: float = 0.05,
+    before_mutation: Callable[[Path], None] | None = None,
+    mutation_context: Callable[[Path], ContextManager[Any]] | None = None,
+    after_mutation_locked: Callable[[Path, T], None] | None = None,
+    after_mutation_unlocked: Callable[[Path, T], None] | None = None,
+) -> T:
+    """Serialize a repository mutation across all interfaces using shared core locks.
+
+    Callers can inject optional orchestration hooks around the actual mutation:
+    - ``before_mutation`` runs inside the lock before the mutation.
+    - ``mutation_context`` supplies an optional context manager around the mutation.
+    - ``after_mutation_locked`` runs after the mutation but before the lock is released.
+    - ``after_mutation_unlocked`` runs after the shared lock is released.
+    """
+    with _REPO_TXN_LOCK:
+        with repo_process_lock(
+            datarepo_path,
+            timeout_seconds=lock_timeout_seconds,
+            poll_interval_seconds=lock_poll_interval_seconds,
+        ):
+            assert_repo_version_matches_tool(datarepo_path)
+            assert_no_upgrade_in_progress(datarepo_path)
+            if before_mutation is not None:
+                before_mutation(datarepo_path)
+            ctx = mutation_context(datarepo_path) if mutation_context is not None else nullcontext()
+            with ctx:
+                result = mutate_fn()
+            if after_mutation_locked is not None:
+                after_mutation_locked(datarepo_path, result)
+    if after_mutation_unlocked is not None:
+        after_mutation_unlocked(datarepo_path, result)
+    return result

--- a/tests/test_api_error_sanitization.py
+++ b/tests/test_api_error_sanitization.py
@@ -96,6 +96,18 @@ class TestUnsafeTypesRedacted:
         assert "/var/run" not in data["error"]
         assert data["error"] == "Request failed"
 
+    def test_upgrade_in_progress_runtime_error_surfaces_actionable_message(self, _app):
+        exc = RuntimeError("Repository upgrade in progress; retry after upgrade completes.")
+        data, code = _call(_app, exc, status=400)
+        assert code == 400
+        assert data["error"] == "Repository upgrade in progress; retry after upgrade completes."
+
+    def test_repo_lock_timeout_runtime_error_surfaces_actionable_message(self, _app):
+        exc = RuntimeError("Timed out waiting for repo lock after 30.0s")
+        data, code = _call(_app, exc, status=400)
+        assert code == 400
+        assert data["error"] == "Another SmallFactory operation is in progress; retry shortly."
+
     def test_safe_exception_multiline_truncated(self, _app):
         exc = ValueError("first line\nsecond line with /secret/path")
         data, _ = _call(_app, exc, status=400)

--- a/tests/test_cli_alias_dispatch.py
+++ b/tests/test_cli_alias_dispatch.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+import pytest
+
+from conftest import init_git_repo
+from smallfactory.core.v1.entities import bom_add_line, create_entity
+from smallfactory.core.v1.repo import write_datarepo_config
+
+
+def _run_cli(monkeypatch: pytest.MonkeyPatch, sf_cli_mod, argv: list[str], *, fmt: str = "json"):
+    out = io.StringIO()
+    err = io.StringIO()
+    monkeypatch.setattr(sys, "argv", ["sf", "--format", fmt, *argv])
+    with redirect_stdout(out), redirect_stderr(err):
+        code = 0
+        try:
+            sf_cli_mod.main()
+        except SystemExit as e:
+            code = int(e.code or 0)
+    return code, out.getvalue(), err.getvalue()
+
+
+@pytest.fixture()
+def env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    init_git_repo(repo)
+    write_datarepo_config(repo)
+    create_entity(repo, "p_widget", {"name": "Widget"})
+    create_entity(repo, "p_parent", {"name": "Parent"})
+    create_entity(repo, "p_child", {"name": "Child"})
+    bom_add_line(repo, "p_parent", use="p_child", qty=1, rev="released")
+
+    from smallfactory.cli import sf_cli
+
+    monkeypatch.setattr(sf_cli, "get_datarepo_path", lambda: repo)
+    return repo, sf_cli
+
+
+def test_entities_list_alias_dispatches(env, monkeypatch: pytest.MonkeyPatch):
+    _, sf_cli = env
+    code, out, err = _run_cli(monkeypatch, sf_cli, ["entities", "list"])
+    assert code == 0, err or out
+    rows = json.loads(out)
+    assert any(row.get("sfid") == "p_widget" for row in rows)
+
+
+def test_entities_view_alias_dispatches(env, monkeypatch: pytest.MonkeyPatch):
+    _, sf_cli = env
+    code, out, err = _run_cli(monkeypatch, sf_cli, ["entities", "view", "p_widget"])
+    assert code == 0, err or out
+    entity = json.loads(out)
+    assert entity.get("sfid") == "p_widget"
+
+
+def test_bom_list_alias_dispatches(env, monkeypatch: pytest.MonkeyPatch):
+    _, sf_cli = env
+    code, out, err = _run_cli(monkeypatch, sf_cli, ["bom", "list", "p_parent"])
+    assert code == 0, err or out
+    rows = json.loads(out)
+    assert any(row.get("use") == "p_child" for row in rows)
+
+
+def test_bom_remove_alias_dispatches(env, monkeypatch: pytest.MonkeyPatch):
+    repo, sf_cli = env
+    code, out, err = _run_cli(monkeypatch, sf_cli, ["bom", "remove", "p_parent", "--use", "p_child"])
+    assert code == 0, err or out
+    payload = json.loads(out)
+    assert payload.get("removed") == [0]
+
+    code, out, err = _run_cli(monkeypatch, sf_cli, ["bom", "list", "p_parent"])
+    assert code == 0, err or out
+    assert json.loads(out) == []

--- a/tests/test_cli_repo_txn_usage.py
+++ b/tests/test_cli_repo_txn_usage.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+import pytest
+
+from conftest import init_git_repo
+from smallfactory.core.v1.repo import write_datarepo_config
+
+
+def _run_cli_json(monkeypatch: pytest.MonkeyPatch, sf_cli_mod, argv: list[str]):
+    out = io.StringIO()
+    err = io.StringIO()
+    monkeypatch.setattr(sys, "argv", ["sf", "--format", "json", *argv])
+    with redirect_stdout(out), redirect_stderr(err):
+        code = 0
+        try:
+            sf_cli_mod.main()
+        except SystemExit as e:
+            code = int(e.code or 0)
+    if code != 0:
+        raise AssertionError(f"CLI failed with code {code}: {err.getvalue() or out.getvalue()}")
+    text = out.getvalue().strip()
+    assert text, f"CLI produced no JSON output for argv={argv!r}"
+    return json.loads(text)
+
+
+@pytest.fixture()
+def env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    init_git_repo(repo)
+    write_datarepo_config(repo)
+
+    from smallfactory.cli import sf_cli
+
+    monkeypatch.setattr(sf_cli, "get_datarepo_path", lambda: repo)
+    return repo, sf_cli
+
+
+def _install_repo_txn_probe(monkeypatch: pytest.MonkeyPatch, sf_cli, repo: Path):
+    calls: list[Path] = []
+
+    def fake_run_repo_mutation(path, mutate_fn, **kwargs):
+        calls.append(path)
+        return mutate_fn()
+
+    monkeypatch.setattr(sf_cli, "run_repo_mutation", fake_run_repo_mutation)
+    return calls
+
+
+def test_cli_inventory_post_uses_shared_repo_txn(env, monkeypatch: pytest.MonkeyPatch):
+    repo, sf_cli = env
+    calls = _install_repo_txn_probe(monkeypatch, sf_cli, repo)
+    monkeypatch.setattr(
+        sf_cli,
+        "inventory_post",
+        lambda *a, **k: {"part": "p_widget", "location": "l_inbox", "qty_delta": 3, "txn": "txn_1"},
+    )
+
+    out = _run_cli_json(
+        monkeypatch,
+        sf_cli,
+        ["inventory", "post", "--part", "p_widget", "--qty-delta", "+3", "--l_sfid", "l_inbox"],
+    )
+
+    assert calls == [repo]
+    assert out["txn"] == "txn_1"
+
+
+def test_cli_inventory_onhand_write_uses_shared_repo_txn(env, monkeypatch: pytest.MonkeyPatch):
+    repo, sf_cli = env
+    calls = _install_repo_txn_probe(monkeypatch, sf_cli, repo)
+    monkeypatch.setattr(
+        sf_cli,
+        "inventory_onhand",
+        lambda *a, **k: {"uom": "ea", "as_of": "2026-04-05T00:00:00Z", "by_location": {"l_inbox": 3}, "total": 3},
+    )
+
+    out = _run_cli_json(monkeypatch, sf_cli, ["inventory", "onhand", "--part", "p_widget"])
+
+    assert calls == [repo]
+    assert out["total"] == 3
+
+
+def test_cli_events_append_uploads_inside_shared_repo_txn(env, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    repo, sf_cli = env
+    calls: list[Path] = []
+    in_txn = {"active": False}
+
+    src = tmp_path / "capture.txt"
+    src.write_text("capture", encoding="utf-8")
+
+    def fake_run_repo_mutation(path, mutate_fn, **kwargs):
+        calls.append(path)
+        in_txn["active"] = True
+        try:
+            return mutate_fn()
+        finally:
+            in_txn["active"] = False
+
+    def fake_upload(*args, **kwargs):
+        assert in_txn["active"] is True
+        return {"path": "event_attachments/evt_1/capture.txt"}
+
+    def fake_append(*args, **kwargs):
+        assert in_txn["active"] is True
+        return {
+            "sfid": "b_evt_mock",
+            "event": {
+                "id": "evt_1",
+                "ts": "2026-04-05T00:00:00Z",
+                "message": "ok",
+                "files": ["event_attachments/evt_1/capture.txt"],
+            },
+        }
+
+    monkeypatch.setattr(sf_cli, "run_repo_mutation", fake_run_repo_mutation)
+    monkeypatch.setattr(sf_cli, "ent_get_entity", lambda *a, **k: {"sfid": "b_evt_mock", "events": []})
+    monkeypatch.setattr(sf_cli, "f_upload_file", fake_upload)
+    monkeypatch.setattr(sf_cli, "ent_append_build_event", fake_append)
+
+    out = _run_cli_json(
+        monkeypatch,
+        sf_cli,
+        ["entities", "events", "append", "b_evt_mock", "--message", "ok", "--upload", str(src)],
+    )
+
+    assert calls == [repo]
+    assert (out.get("event") or {}).get("files") == ["event_attachments/evt_1/capture.txt"]
+
+
+@pytest.mark.parametrize(
+    ("argv", "patch_attr", "patch_result", "expected_key"),
+    [
+        (["inventory", "rebuild"], "inventory_rebuild", {"parts": ["p_widget"], "locations": ["l_inbox"]}, "parts"),
+        (["entities", "set", "p_widget", "name=Updated"], "ent_update_entity_fields", {"sfid": "p_widget", "name": "Updated"}, "name"),
+        (["entities", "retire", "p_widget", "--reason", "obsolete"], "ent_retire_entity", {"sfid": "p_widget", "retired": True}, "retired"),
+        (["entities", "build", "serial", "b_2026_0001", "SN123"], "ent_update_entity_fields", {"sfid": "b_2026_0001", "serialnumber": "SN123"}, "serialnumber"),
+        (
+            ["entities", "build", "datetime", "b_2026_0001", "2026-04-05T12:00:00Z"],
+            "ent_update_entity_fields",
+            {"sfid": "b_2026_0001", "datetime": "2026-04-05T12:00:00Z"},
+            "datetime",
+        ),
+        (["entities", "files", "mkdir", "p_widget", "reports"], "f_mkdir", {"path": "reports"}, "path"),
+        (["entities", "events", "update", "b_evt_001", "evt_1", "--message", "updated"], "ent_update_build_event", {"event": {"id": "evt_1"}}, "event"),
+        (["entities", "events", "tags", "b_evt_001", "evt_1", "--tags", "qa,pass"], "ent_update_build_event_tags", {"event": {"tags": ["qa", "pass"]}}, "event"),
+        (
+            ["entities", "events", "link-file", "b_evt_001", "evt_1", "event_attachments/evt_1/log.txt"],
+            "ent_add_build_event_file_link",
+            {"event": {"files": ["event_attachments/evt_1/log.txt"]}},
+            "event",
+        ),
+        (["entities", "revision", "new", "p_widget", "A"], "ent_cut_revision", {"sfid": "p_widget", "rev": "A"}, "rev"),
+        (["entities", "revision", "release", "p_widget", "A"], "ent_release_revision", {"sfid": "p_widget", "rev": "A"}, "rev"),
+        (["bom", "add", "p_parent", "--use", "p_child"], "ent_bom_add_line", {"index": 0, "line": {"use": "p_child"}}, "index"),
+        (["bom", "rm", "p_parent", "--use", "p_child"], "ent_bom_remove_line", {"removed": 1}, "removed"),
+        (["bom", "set", "p_parent", "--index", "0", "--qty", "2"], "ent_bom_set_line", {"line": {"qty": 2}}, "line"),
+        (["bom", "alt-add", "p_parent", "--index", "0", "--use", "p_alt"], "ent_bom_alt_add", {"line": {"alternates": [{"use": "p_alt"}]}}, "line"),
+        (["bom", "alt-rm", "p_parent", "--index", "0", "--alt-use", "p_alt"], "ent_bom_alt_remove", {"line": {"alternates": []}}, "line"),
+    ],
+)
+def test_cli_mutators_use_shared_repo_txn(
+    env,
+    monkeypatch: pytest.MonkeyPatch,
+    argv: list[str],
+    patch_attr: str,
+    patch_result: dict,
+    expected_key: str,
+):
+    repo, sf_cli = env
+    calls = _install_repo_txn_probe(monkeypatch, sf_cli, repo)
+
+    if argv[:4] == ["entities", "events", "update", "b_evt_001"]:
+        monkeypatch.setattr(sf_cli, "ent_get_entity", lambda *a, **k: {"sfid": "b_evt_001", "events": []})
+
+    monkeypatch.setattr(sf_cli, patch_attr, lambda *a, **k: patch_result)
+
+    out = _run_cli_json(monkeypatch, sf_cli, argv)
+
+    assert calls == [repo]
+    assert expected_key in out
+
+
+def test_cli_files_add_uses_shared_repo_txn(env, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    repo, sf_cli = env
+    calls = _install_repo_txn_probe(monkeypatch, sf_cli, repo)
+    src = tmp_path / "capture.txt"
+    src.write_text("capture", encoding="utf-8")
+
+    monkeypatch.setattr(sf_cli, "f_upload_file", lambda *a, **k: {"path": "capture.txt"})
+
+    out = _run_cli_json(monkeypatch, sf_cli, ["entities", "files", "add", "p_widget", str(src), "capture.txt"])
+
+    assert calls == [repo]
+    assert out["path"] == "capture.txt"
+
+
+def test_cli_files_move_dir_uses_shared_repo_txn(env, monkeypatch: pytest.MonkeyPatch):
+    repo, sf_cli = env
+    calls = _install_repo_txn_probe(monkeypatch, sf_cli, repo)
+
+    monkeypatch.setattr(sf_cli, "f_move_dir", lambda *a, **k: {"src": "old", "dst": "new"})
+
+    out = _run_cli_json(monkeypatch, sf_cli, ["entities", "files", "mv", "p_widget", "old", "new", "--dir"])
+
+    assert calls == [repo]
+    assert out["dst"] == "new"
+
+
+def test_cli_revision_bump_wraps_bump_and_release_inside_one_shared_repo_txn(env, monkeypatch: pytest.MonkeyPatch):
+    repo, sf_cli = env
+    calls = _install_repo_txn_probe(monkeypatch, sf_cli, repo)
+    in_txn = {"active": False}
+
+    def fake_run_repo_mutation(path, mutate_fn, **kwargs):
+        calls.append(path)
+        in_txn["active"] = True
+        try:
+            return mutate_fn()
+        finally:
+            in_txn["active"] = False
+
+    def fake_bump(*args, **kwargs):
+        assert in_txn["active"] is True
+        return {"new_rev": "B"}
+
+    def fake_release(*args, **kwargs):
+        assert in_txn["active"] is True
+        return {"sfid": "p_widget", "rev": "B"}
+
+    monkeypatch.setattr(sf_cli, "run_repo_mutation", fake_run_repo_mutation)
+    monkeypatch.setattr(sf_cli, "ent_bump_revision", fake_bump)
+    monkeypatch.setattr(sf_cli, "ent_release_revision", fake_release)
+
+    out = _run_cli_json(monkeypatch, sf_cli, ["entities", "revision", "bump", "p_widget"])
+
+    assert calls == [repo]
+    assert out["rev"] == "B"

--- a/tests/test_cli_web_repo_txn_integration.py
+++ b/tests/test_cli_web_repo_txn_integration.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from conftest import import_web_app_module, init_git_repo
+from smallfactory.core.v1.entities import create_entity, get_entity
+from smallfactory.core.v1.locks import repo_process_lock, upgrade_in_progress_marker
+from smallfactory.core.v1.repo import write_datarepo_config
+
+pytest.importorskip("flask", reason="Flask not installed; web API tests skipped")
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_cli(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "sf.py", "-R", str(repo), "--format", "json", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture()
+def web_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    init_git_repo(repo)
+    write_datarepo_config(repo)
+    create_entity(repo, "p_widget", {"name": "Widget"})
+
+    mod = import_web_app_module()
+    monkeypatch.setattr(mod, "get_datarepo_path", lambda: repo)
+    monkeypatch.setenv("SF_WEB_AUTOPUSH", "0")
+    mod.app.config["TESTING"] = True
+    return repo, mod
+
+
+def test_cli_and_web_mutations_wait_on_same_shared_repo_lock(web_env):
+    repo, mod = web_env
+    web_started = threading.Event()
+    web_result: dict[str, object] = {}
+
+    def web_worker() -> None:
+        web_started.set()
+        with mod.app.test_client() as client:
+            resp = client.post("/api/entities/p_widget/update", json={"category": "electrical"})
+            web_result["status_code"] = resp.status_code
+            web_result["json"] = resp.get_json()
+
+    with repo_process_lock(repo, timeout_seconds=1.0, poll_interval_seconds=0.01):
+        thread = threading.Thread(target=web_worker, daemon=True)
+        thread.start()
+        assert web_started.wait(timeout=1.0) is True
+
+        cli = subprocess.Popen(
+            [
+                sys.executable,
+                "sf.py",
+                "-R",
+                str(repo),
+                "--format",
+                "json",
+                "entities",
+                "set",
+                "p_widget",
+                "serialnumber=SN123",
+            ],
+            cwd=ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        time.sleep(0.25)
+        assert thread.is_alive() is True
+        assert cli.poll() is None
+
+    thread.join(timeout=5.0)
+    assert thread.is_alive() is False
+    cli_out, cli_err = cli.communicate(timeout=5.0)
+    assert cli.returncode == 0, cli_err or cli_out
+
+    assert web_result["status_code"] == 200
+    assert (web_result["json"] or {}).get("success") is True
+
+    entity = get_entity(repo, "p_widget")
+    assert entity["category"] == "electrical"
+    assert entity["serialnumber"] == "SN123"
+
+
+def test_cli_and_web_mutations_are_blocked_during_upgrade(web_env):
+    repo, mod = web_env
+
+    with upgrade_in_progress_marker(repo):
+        cli = _run_cli(repo, "entities", "set", "p_widget", "serialnumber=SN999")
+        assert cli.returncode != 0
+        assert "upgrade in progress" in (cli.stderr or cli.stdout).lower()
+
+        with mod.app.test_client() as client:
+            resp = client.post("/api/entities/p_widget/update", json={"category": "blocked"})
+
+        assert resp.status_code == 400
+        payload = resp.get_json() or {}
+        assert payload.get("success") is False
+        assert payload.get("error") == "Repository upgrade in progress; retry after upgrade completes."
+
+    entity = get_entity(repo, "p_widget")
+    assert entity.get("category") != "blocked"
+    assert entity.get("serialnumber") != "SN999"

--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _docker_enabled() -> bool:
+    return shutil.which("docker") is not None and os.getenv("SF_RUN_DOCKER_TESTS") == "1"
+
+
+pytestmark = pytest.mark.skipif(
+    not _docker_enabled(),
+    reason="Docker integration tests require docker plus SF_RUN_DOCKER_TESTS=1",
+)
+
+
+def _run(cmd: list[str], *, cwd: Path = ROOT, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"command failed ({result.returncode}): {' '.join(cmd)}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _http_request(
+    url: str,
+    *,
+    method: str = "GET",
+    data: bytes | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, str], bytes]:
+    request = urllib.request.Request(url, data=data, headers=headers or {}, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=5.0) as resp:
+            return int(resp.status), dict(resp.headers.items()), resp.read()
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), dict(exc.headers.items()), exc.read()
+
+
+def _wait_for_ok(url: str, *, timeout: float = 30.0) -> None:
+    deadline = time.time() + timeout
+    last_status = None
+    last_body = b""
+    while time.time() < deadline:
+        try:
+            status, _, body = _http_request(url)
+            last_status = status
+            last_body = body
+            if status == 200:
+                return
+        except Exception as exc:
+            last_status = None
+            last_body = str(exc).encode("utf-8", errors="ignore")
+        time.sleep(0.25)
+    raise AssertionError(f"timed out waiting for {url}; last_status={last_status}, body={last_body[:200]!r}")
+
+
+def _docker_logs(name: str) -> str:
+    result = _run(["docker", "logs", name], check=False)
+    return (result.stdout or "") + (result.stderr or "")
+
+
+@pytest.fixture(scope="session")
+def docker_image_tag() -> str:
+    info = _run(["docker", "info"], check=False)
+    if info.returncode != 0:
+        pytest.skip(f"docker daemon unavailable: {info.stderr or info.stdout}")
+
+    tag = f"smallfactory-test:{uuid.uuid4().hex[:8]}"
+    _run(["docker", "build", "-t", tag, "."])
+    return tag
+
+
+def test_docker_web_mcp_persistence_and_host_file_workflow(tmp_path: Path, docker_image_tag: str):
+    data_dir = tmp_path / "data"
+    work_dir = tmp_path / "work"
+    data_dir.mkdir(parents=True)
+    work_dir.mkdir(parents=True)
+    payload_path = work_dir / "payload.txt"
+    payload_path.write_text("captured from host", encoding="utf-8")
+
+    name1 = f"sf-web-{uuid.uuid4().hex[:8]}"
+    name2 = f"sf-web-{uuid.uuid4().hex[:8]}"
+    port1 = _free_port()
+    port2 = _free_port()
+    base1 = f"http://127.0.0.1:{port1}"
+    base2 = f"http://127.0.0.1:{port2}"
+
+    try:
+        _run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--name",
+                name1,
+                "-p",
+                f"{port1}:8080",
+                "-e",
+                "SF_WEB_AUTOPUSH=0",
+                "-v",
+                f"{data_dir}:/data",
+                docker_image_tag,
+            ]
+        )
+        _wait_for_ok(f"{base1}/")
+
+        init_payload = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "pytest", "version": "0"},
+                },
+            }
+        ).encode("utf-8")
+        status, headers, body = _http_request(
+            f"{base1}/mcp",
+            method="POST",
+            data=init_payload,
+            headers={
+                "content-type": "application/json",
+                "accept": "application/json, text/event-stream",
+            },
+        )
+        assert status == 200, _docker_logs(name1)
+        assert headers.get("mcp-session-id"), headers
+        assert b"smallfactory" in body
+
+        _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-v",
+                f"{data_dir}:/data",
+                docker_image_tag,
+                "entities",
+                "add",
+                "p_widget",
+                "name=Widget",
+            ]
+        )
+        _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-v",
+                f"{data_dir}:/data",
+                "-v",
+                f"{work_dir}:/work",
+                docker_image_tag,
+                "entities",
+                "files",
+                "add",
+                "p_widget",
+                "/work/payload.txt",
+                "payloads/payload.txt",
+            ]
+        )
+
+        attached = data_dir / "datarepo" / "entities" / "p_widget" / "files" / "payloads" / "payload.txt"
+        assert attached.read_text(encoding="utf-8") == "captured from host"
+
+        _run(["docker", "rm", "-f", name1], check=False)
+
+        _run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--name",
+                name2,
+                "-p",
+                f"{port2}:8080",
+                "-e",
+                "SF_WEB_AUTOPUSH=0",
+                "-v",
+                f"{data_dir}:/data",
+                docker_image_tag,
+            ]
+        )
+        _wait_for_ok(f"{base2}/entities/p_widget")
+        status, _, body = _http_request(f"{base2}/entities/p_widget")
+        assert status == 200, _docker_logs(name2)
+        assert b"Widget" in body
+        assert attached.is_file()
+    finally:
+        _run(["docker", "rm", "-f", name1], check=False)
+        _run(["docker", "rm", "-f", name2], check=False)

--- a/tests/test_entrypoint_bootstrap.py
+++ b/tests/test_entrypoint_bootstrap.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from conftest import git_commit_count
+
+ROOT = Path(__file__).resolve().parents[1]
+ENTRYPOINT = ROOT / "docker" / "entrypoint.sh"
+
+
+def _entrypoint_env(data_path: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HOME"] = str(data_path / "home")
+    env["SF_DATA_PATH"] = str(data_path)
+    env["SF_REPO_PATH"] = str(data_path / "datarepo")
+    env["PORT"] = "8080"
+    Path(env["HOME"]).mkdir(parents=True, exist_ok=True)
+    return env
+
+
+def test_entrypoint_bootstrap_is_safe_under_parallel_first_run(tmp_path: Path):
+    data_path = tmp_path / "data"
+    data_path.mkdir(parents=True)
+    env = _entrypoint_env(data_path)
+
+    p1 = subprocess.Popen(
+        ["bash", str(ENTRYPOINT), "repo", "status"],
+        cwd=ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    p2 = subprocess.Popen(
+        ["bash", str(ENTRYPOINT), "repo", "status"],
+        cwd=ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    out1, err1 = p1.communicate(timeout=30.0)
+    out2, err2 = p2.communicate(timeout=30.0)
+
+    assert p1.returncode == 0, err1 or out1
+    assert p2.returncode == 0, err2 or out2
+
+    repo = data_path / "datarepo"
+    assert (repo / ".git").is_dir()
+    assert (repo / "sfdatarepo.yml").is_file()
+    assert (repo / "entities" / "l_inbox" / "entity.yml").is_file()
+    assert git_commit_count(repo) == 2
+
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert (status.stdout or "").strip() == ""

--- a/tests/test_web_route_smoke.py
+++ b/tests/test_web_route_smoke.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from jinja2 import FileSystemLoader
+
+from conftest import import_web_app_module, init_git_repo
+from smallfactory.core.v1.entities import bom_add_line, create_entity
+from smallfactory.core.v1.repo import write_datarepo_config
+
+pytest.importorskip("flask", reason="Flask not installed; web route tests skipped")
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    init_git_repo(repo)
+    write_datarepo_config(repo)
+    create_entity(repo, "p_widget", {"name": "Widget"})
+    create_entity(repo, "p_child", {"name": "Child"})
+    create_entity(repo, "b_test_001", {"name": "Build Record", "part_sfid": "p_widget"})
+    bom_add_line(repo, "p_widget", use="p_child", qty=1, rev="released")
+
+    mod = import_web_app_module()
+    monkeypatch.setattr(mod, "get_datarepo_path", lambda: repo)
+    monkeypatch.setenv("SF_WEB_AUTOPUSH", "0")
+    mod.app.config["TESTING"] = True
+    template_root = Path(__file__).resolve().parents[1] / "web" / "templates"
+    mod.app.template_folder = str(template_root)
+    mod.app.jinja_loader = FileSystemLoader(str(template_root))
+
+    with mod.app.test_client() as client:
+        yield client
+
+
+@pytest.mark.parametrize(
+    ("path", "follow_redirects"),
+    [
+        ("/", False),
+        ("/inventory", False),
+        ("/inventory/adjust", False),
+        ("/entities", False),
+        ("/entities/add", False),
+        ("/entities/p_widget", False),
+        ("/entities/p_widget/build", False),
+        ("/entities/p_widget/bom/import", False),
+        ("/entities/p_widget/bom-tree", False),
+        ("/entities/b_test_001", False),
+        ("/stickers", True),
+        ("/stickers/batch", False),
+        ("/vision", False),
+        ("/announcements", False),
+        ("/repo/stats", False),
+    ],
+)
+def test_canonical_web_pages_render_successfully(client, path: str, follow_redirects: bool):
+    resp = client.get(path, follow_redirects=follow_redirects)
+
+    assert resp.status_code == 200
+    assert resp.content_type.startswith("text/html")

--- a/web/app.py
+++ b/web/app.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import List
 import time
 import atexit
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 import tarfile
 from jinja2 import ChoiceLoader, FileSystemLoader
 
@@ -64,11 +64,7 @@ from smallfactory.core.v1.stickers import (
     generate_sticker_for_entity,
     check_dependencies as stickers_check_deps,
 )
-from smallfactory.core.v1.locks import (
-    assert_no_upgrade_in_progress as core_assert_no_upgrade_in_progress,
-    repo_process_lock as core_repo_process_lock,
-)
-from smallfactory.core.v1.versioning import assert_repo_version_matches_tool
+from smallfactory.core.v1.transactions import run_repo_mutation
 from smallfactory.core.v1.vision import (
     ask_image as vlm_ask_image,
     extract_invoice_part as vlm_extract_invoice_part,
@@ -94,12 +90,25 @@ def _api_exception_response(
     except Exception:
         pass
     error_message = public_message
+    def _operational_runtime_message(err: Exception) -> str | None:
+        text = str(err or "").strip()
+        low = text.lower()
+        if "repository upgrade in progress" in low:
+            return "Repository upgrade in progress; retry after upgrade completes."
+        if "timed out waiting for repo lock" in low:
+            return "Another SmallFactory operation is in progress; retry shortly."
+        return None
+
     # Surface concise validation feedback for known user-input exceptions only.
     _SAFE_EXC_TYPES = (ValueError, KeyError, IndexError, FileNotFoundError, FileExistsError)
-    if public_message == "Request failed" and status < 500 and isinstance(exc, _SAFE_EXC_TYPES):
-        detail = str(exc).strip().split("\n", 1)[0]
-        if detail:
-            error_message = detail[:240]
+    if public_message == "Request failed" and status < 500:
+        operational_message = _operational_runtime_message(exc)
+        if operational_message:
+            error_message = operational_message
+        elif isinstance(exc, _SAFE_EXC_TYPES):
+            detail = str(exc).strip().split("\n", 1)[0]
+            if detail:
+                error_message = detail[:240]
     payload = {"success": False, "error": error_message}
     if hint:
         payload["hint"] = hint
@@ -892,18 +901,6 @@ def _get_repo_txn_lock_timeout_sec() -> float:
         return 30.0
 
 
-@contextmanager
-def _repo_process_lock(datarepo_path: Path):
-    """Cross-process repo mutation lock using shared core lock helper."""
-    timeout_sec = _get_repo_txn_lock_timeout_sec()
-    with core_repo_process_lock(
-        datarepo_path,
-        timeout_seconds=timeout_sec,
-        poll_interval_seconds=0.05,
-    ):
-        yield
-
-
 def _push_worker(datarepo_path: Path) -> None:
     t0 = time.time()
     _dgit('async push: start')
@@ -1167,51 +1164,59 @@ def _run_repo_txn(datarepo_path: Path, mutate_fn):
         return mutate_fn()
     need_async_push = False
     schedule_delayed = False
-    with _REPO_TXN_LOCK:
-        with _repo_process_lock(datarepo_path):
-            assert_repo_version_matches_tool(datarepo_path)
-            core_assert_no_upgrade_in_progress(datarepo_path)
-            ok, err = _safe_git_pull(datarepo_path)
-            if not ok:
-                raise RuntimeError(f"Pre-mutation git pull failed: {err}")
-            # Extract per-request identity from proxy headers (if present)
-            name, email = _extract_identity_from_headers(request)
-            def _do_mutate():
-                return mutate_fn()
-            if name and email:
-                with _with_git_identity(name, email):
-                    result = _do_mutate()
-            else:
-                result = _do_mutate()
-            # Conditional push
-            if _autopush_enabled():
-                ttl = _get_push_ttl_sec()
-                if ttl and ttl > 0:
-                    # Defer push to batch within TTL window (always async)
-                    schedule_delayed = True
-                else:
-                    if _autopush_async_enabled():
-                        need_async_push = True
-                    else:
-                        try:
-                            t0 = time.time()
-                            with _PUSH_LOCK:
-                                okp = git_push(datarepo_path)
-                            _dgit(f'sync push: done {int((time.time()-t0)*1000)}ms ok={okp}')
-                            if okp:
-                                _GIT_LAST_PUSH[str(datarepo_path)] = time.time()
-                        except Exception as e:
-                            try:
-                                _dgit(f'sync push: failed ({e})')
-                            except Exception:
-                                pass
-                            raise RuntimeError(f"Post-mutation git push failed: {e}")
-    # If async push is enabled, run it after releasing the txn lock
-    if need_async_push:
-        _spawn_async_push(datarepo_path)
-    if schedule_delayed:
-        _schedule_delayed_push(datarepo_path)
-    return result
+    name, email = _extract_identity_from_headers(request)
+
+    def _pre_mutation(_: Path) -> None:
+        ok, err = _safe_git_pull(datarepo_path)
+        if not ok:
+            raise RuntimeError(f"Pre-mutation git pull failed: {err}")
+
+    def _mutation_context(_: Path):
+        if name and email:
+            return _with_git_identity(name, email)
+        return nullcontext()
+
+    def _after_mutation_locked(_: Path, _result):
+        nonlocal need_async_push, schedule_delayed
+        if not _autopush_enabled():
+            return
+        ttl = _get_push_ttl_sec()
+        if ttl and ttl > 0:
+            schedule_delayed = True
+            return
+        if _autopush_async_enabled():
+            need_async_push = True
+            return
+        try:
+            t0 = time.time()
+            with _PUSH_LOCK:
+                okp = git_push(datarepo_path)
+            _dgit(f'sync push: done {int((time.time()-t0)*1000)}ms ok={okp}')
+            if okp:
+                _GIT_LAST_PUSH[str(datarepo_path)] = time.time()
+        except Exception as e:
+            try:
+                _dgit(f'sync push: failed ({e})')
+            except Exception:
+                pass
+            raise RuntimeError(f"Post-mutation git push failed: {e}")
+
+    def _after_mutation_unlocked(_: Path, _result) -> None:
+        if need_async_push:
+            _spawn_async_push(datarepo_path)
+        if schedule_delayed:
+            _schedule_delayed_push(datarepo_path)
+
+    return run_repo_mutation(
+        datarepo_path,
+        mutate_fn,
+        lock_timeout_seconds=_get_repo_txn_lock_timeout_sec(),
+        lock_poll_interval_seconds=0.05,
+        before_mutation=_pre_mutation,
+        mutation_context=_mutation_context,
+        after_mutation_locked=_after_mutation_locked,
+        after_mutation_unlocked=_after_mutation_unlocked,
+    )
 
 
 # -----------------------


### PR DESCRIPTION
## Summary
- add a supported Docker/Compose deployment path plus host-invoked Docker CLI workflow
- move repo mutation coordination into shared core transaction logic used by both web and CLI
- add regression coverage for alias dispatch, shared locking, web routes, entrypoint bootstrap, and Docker integration

## Testing
- pytest -q
- SF_RUN_DOCKER_TESTS=1 pytest -q tests/test_docker_integration.py