### PR TITLE
Publish latest image for stable releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,9 @@
 name: Build and Publish Docker image
 
 on:
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
       push_image:
@@ -23,6 +26,8 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    env:
+      SHOULD_PUSH: ${{ github.event_name == 'release' || inputs.push_image == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,7 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: inputs.push_image == 'true'
+        if: env.SHOULD_PUSH == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -47,7 +52,8 @@ jobs:
             type=sha
             type=ref,event=tag
             type=ref,event=branch
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
             ${{ format('type=raw,value={0}', inputs.tags) }}
 
       - name: Compute version metadata
@@ -65,7 +71,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ inputs.push_image == 'true' }}
+          push: ${{ env.SHOULD_PUSH == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ http://127.0.0.1:8080
 smallFactory now supports a single-image Docker workflow for both the web app
 and ad hoc CLI usage against the same persisted data repo.
 
-Quick start with Compose:
+Quick start with the official image:
 
 ```sh
-docker compose up --build
+docker pull ghcr.io/yusufm/smallfactory:latest
+docker run --rm -it -p 8080:8080 -v smallfactory-data:/data ghcr.io/yusufm/smallfactory:latest
 # Web UI: http://127.0.0.1:8080
 # MCP:    http://127.0.0.1:8080/mcp
 ```
@@ -92,16 +93,18 @@ docker compose up --build
 Run CLI commands without attaching to the running container:
 
 ```sh
-docker compose run --rm smallfactory inventory onhand --readonly
-docker compose run --rm smallfactory entities ls
-./scripts/sf-docker.sh inventory onhand --readonly
+docker run --rm -it -v smallfactory-data:/data ghcr.io/yusufm/smallfactory:latest inventory onhand --readonly
+docker run --rm -it -v smallfactory-data:/data ghcr.io/yusufm/smallfactory:latest entities ls
 ```
 
-Plain Docker works too:
+For reproducible deployments, prefer an explicit release tag instead of `latest`.
+
+If you are working from a local checkout and want to build from source instead:
 
 ```sh
-docker run --rm -it -p 8080:8080 -v smallfactory-data:/data smallfactory:local
-docker run --rm -it -v smallfactory-data:/data smallfactory:local repo validate
+docker compose up --build
+docker compose run --rm smallfactory inventory onhand --readonly
+./scripts/sf-docker.sh inventory onhand --readonly
 ```
 
 Container defaults:

--- a/docs/users/docker.md
+++ b/docs/users/docker.md
@@ -24,12 +24,16 @@ mounted data repository.
 - Advisory file locks are used for repo and journal mutations. Prefer a local
   Docker volume or a local-disk bind mount over a network filesystem.
 
-## Quick Start With Docker Compose
+## Quick Start With The Official Image
 
-Build and start the web UI:
+Pull and start the latest stable image:
 
 ```bash
-docker compose up --build
+docker pull ghcr.io/yusufm/smallfactory:latest
+docker run --rm -it \
+  -p 8080:8080 \
+  -v smallfactory-data:/data \
+  ghcr.io/yusufm/smallfactory:latest
 ```
 
 Then open:
@@ -37,31 +41,52 @@ Then open:
 - Web UI: `http://127.0.0.1:8080`
 - MCP: `http://127.0.0.1:8080/mcp`
 
+For reproducible production or team setups, prefer a pinned release tag instead
+of `latest`, for example `ghcr.io/yusufm/smallfactory:v1.1.0`.
+
+## Quick Start From Source
+
+If you are working from a local checkout and want to build the image yourself:
+
+```bash
+docker compose up --build
+```
+
 The included [compose.yaml](../../compose.yaml) stores data in the named volume
-`smallfactory-data`.
+`smallfactory-data` and is best suited for local development, source testing,
+and contributors.
 
 ## Easy CLI Usage Without Entering The Running Container
 
 Run ad hoc CLI commands against the same persisted volume:
 
 ```bash
-docker compose run --rm smallfactory inventory onhand --readonly
-docker compose run --rm smallfactory entities ls
-docker compose run --rm smallfactory repo validate
+docker run --rm -it \
+  -v smallfactory-data:/data \
+  ghcr.io/yusufm/smallfactory:latest \
+  inventory onhand --readonly
+docker run --rm -it \
+  -v smallfactory-data:/data \
+  ghcr.io/yusufm/smallfactory:latest \
+  entities ls
+docker run --rm -it \
+  -v smallfactory-data:/data \
+  ghcr.io/yusufm/smallfactory:latest \
+  repo validate
 ```
 
-There is also a thin wrapper in this repo:
+From a source checkout, there is also a thin wrapper in this repo:
 
 ```bash
 ./scripts/sf-docker.sh inventory onhand --readonly
 ./scripts/sf-docker.sh entities ls
 ```
 
-You can do the same with plain Docker:
+And from a source checkout you can use Compose directly:
 
 ```bash
-docker run --rm -it -p 8080:8080 -v smallfactory-data:/data smallfactory:local
-docker run --rm -it -v smallfactory-data:/data smallfactory:local inventory onhand --readonly
+docker compose run --rm smallfactory inventory onhand --readonly
+docker compose run --rm smallfactory entities ls
 ```
 
 The image accepts direct smallFactory commands, so you do not need
@@ -87,7 +112,7 @@ Example:
 docker run --rm -it \
   -v smallfactory-data:/data \
   -v "$PWD:/work" \
-  smallfactory:local \
+  ghcr.io/yusufm/smallfactory:latest \
   entities files add p_widget /work/test-output/log.txt logs/test-output.txt
 ```
 
@@ -113,7 +138,7 @@ docker run --rm -it \
   -p 8080:8080 \
   -e SF_REPO_GIT_URL=https://github.com/you/your-datarepo.git \
   -v smallfactory-data:/data \
-  smallfactory:local
+  ghcr.io/yusufm/smallfactory:latest
 ```
 
 If your repo should live at a different path, mount its parent and set
@@ -131,7 +156,7 @@ docker run --rm -it \
   --user "$(id -u):$(id -g)" \
   -p 8080:8080 \
   -v "$PWD/docker-data:/data" \
-  smallfactory:local
+  ghcr.io/yusufm/smallfactory:latest
 ```
 
 ## MCP In Docker
@@ -156,7 +181,7 @@ docker run --rm -it \
   -e SF_VISION_PROVIDER=ollama \
   -e SF_OLLAMA_BASE_URL=http://host.docker.internal:11434 \
   -v smallfactory-data:/data \
-  smallfactory:local
+  ghcr.io/yusufm/smallfactory:latest
 ```
 
 On Linux, you may also need:


### PR DESCRIPTION
## Summary
- trigger the Docker publish workflow on GitHub release publication
- publish the release tag to GHCR automatically
- also move the `latest` tag only for non-prerelease stable releases

## Notes
- prereleases keep their explicit release tag but do not update `latest`
- manual workflow dispatch still supports build-only or build-and-push runs