### PR TITLE
Publish multi-arch release images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -71,6 +74,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ env.SHOULD_PUSH == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- add QEMU to the Docker publish workflow
- publish release images for both linux/amd64 and linux/arm64
- keep the existing release tag and latest-tag behavior unchanged

## Why
- v1.2.0 currently publishes only linux/amd64, so Apple Silicon hosts cannot pull it normally
- this change makes GHCR releases usable on both Intel and Apple Silicon machines