### PR TITLE
Add build status UI and list handling

### DIFF
--- a/tests/test_web_entity_crud.py
+++ b/tests/test_web_entity_crud.py
@@ -153,6 +153,17 @@ class TestEntityUpdate:
         assert ent["category"] == "IC"
         assert ent["manufacturer"] == "TI"
 
+    def test_update_build_status(self, client):
+        create_entity(_repo(client), "b_upd_001", {"name": "Build Upd", "part_sfid": "p_missing"})
+        resp = client.post(
+            "/api/entities/b_upd_001/update",
+            json={"updates": {"status": "in_progress"}},
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["entity"]["status"] == "in_progress"
+
 
 # ---------------------------------------------------------------------------
 # Entity retirement (POST /entities/<sfid>/retire — form-based, redirects)

--- a/tests/test_web_route_smoke.py
+++ b/tests/test_web_route_smoke.py
@@ -32,6 +32,7 @@ def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     mod.app.jinja_loader = FileSystemLoader(str(template_root))
 
     with mod.app.test_client() as client:
+        client._repo = repo
         yield client
 
 
@@ -60,3 +61,63 @@ def test_canonical_web_pages_render_successfully(client, path: str, follow_redir
 
     assert resp.status_code == 200
     assert resp.content_type.startswith("text/html")
+
+
+def test_build_entity_view_renders_status_field(client):
+    create_entity(
+        client._repo,
+        "b_test_002",
+        {
+            "name": "Build In Progress",
+            "part_sfid": "p_widget",
+            "status": "in_progress",
+            "opened_at": "2026-04-05T12:00:00Z",
+        },
+    )
+
+    resp = client.get("/entities/b_test_002")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Build In Progress" in body
+    assert "in_progress" in body
+
+
+def test_dashboard_recent_builds_uses_build_statuses(client):
+    create_entity(
+        client._repo,
+        "b_test_003",
+        {
+            "name": "Build Complete",
+            "part_sfid": "p_widget",
+            "status": "completed",
+            "opened_at": "2026-04-05T12:00:00Z",
+        },
+    )
+
+    resp = client.get("/")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Build Complete" in body
+    assert "completed" in body
+
+
+def test_builds_list_shows_build_status_not_entity_state(client):
+    create_entity(
+        client._repo,
+        "b_test_004",
+        {
+            "name": "Build Open",
+            "part_sfid": "p_widget",
+            "status": "open",
+        },
+    )
+
+    resp = client.get("/entities?type=b")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Build Open" in body
+    assert "open" in body
+    assert "Active" not in body

--- a/web/templates/entities/list.html
+++ b/web/templates/entities/list.html
@@ -49,7 +49,7 @@
         <thead class="bg-gray-50">
           <tr>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name / SFID</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{% if filter_type == 'b' %}Status{% else %}State{% endif %}</th>
             <th class="px-6 py-3"></th>
           </tr>
         </thead>
@@ -65,7 +65,15 @@
               </div>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm">
-              {% if e.get('retired') %}
+              {% if filter_type == 'b' %}
+                {% set build_status = (e.get('status') or 'unknown')|lower %}
+                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full
+                  {{ 'bg-green-100 text-green-800' if build_status == 'completed' else
+                     'bg-blue-100 text-blue-800' if build_status == 'in_progress' else
+                     'bg-red-100 text-red-800' if build_status == 'canceled' else
+                     'bg-amber-100 text-amber-800' if build_status == 'open' else
+                     'bg-gray-100 text-gray-800' }}">{{ build_status }}</span>
+              {% elif e.get('retired') %}
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">Retired</span>
               {% else %}
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Active</span>

--- a/web/templates/entities/view.html
+++ b/web/templates/entities/view.html
@@ -123,6 +123,21 @@
               <dd id="ovw-name-display" class="mt-1 text-sm text-gray-900">{{ entity.get('name', entity.sfid) }}</dd>
             </div>
             {% if entity.sfid and entity.sfid[:2] == 'b_' %}
+            {% set build_status = (entity.get('status') or '').lower() %}
+            <div>
+              <dt class="text-sm font-medium text-gray-600">Status</dt>
+              <dd class="mt-1">
+                <span
+                  id="ovw-status-display"
+                  class="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium
+                    {{ 'bg-green-100 text-green-800' if build_status == 'completed' else
+                       'bg-blue-100 text-blue-800' if build_status == 'in_progress' else
+                       'bg-red-100 text-red-800' if build_status == 'canceled' else
+                       'bg-amber-100 text-amber-800' if build_status == 'open' else
+                       'bg-gray-100 text-gray-700' }}"
+                >{{ build_status or '—' }}</span>
+              </dd>
+            </div>
             <div>
               <dt class="text-sm font-medium text-gray-600">Serial Number</dt>
               <dd id="ovw-serialnumber-display" class="mt-1 text-sm font-mono text-gray-900">{{ entity.get('serialnumber') or '—' }}</dd>
@@ -253,6 +268,17 @@
                 <input id="ovw-name" type="text" value="{{ entity.get('name', '') }}" class="mt-1 w-full border border-gray-300 rounded-md px-3 py-2">
               </div>
               {% if entity.sfid and entity.sfid[:2] == 'b_' %}
+              <div>
+                <label class="block text-xs font-medium text-gray-700">Status</label>
+                {% set bsel = (entity.get('status') or '')|lower %}
+                <select id="ovw-status" class="mt-1 w-full border border-gray-300 rounded-md px-3 py-2">
+                  <option value="" {% if not bsel %}selected{% endif %}>(unspecified)</option>
+                  <option value="open" {% if bsel == 'open' %}selected{% endif %}>open</option>
+                  <option value="in_progress" {% if bsel == 'in_progress' %}selected{% endif %}>in_progress</option>
+                  <option value="completed" {% if bsel == 'completed' %}selected{% endif %}>completed</option>
+                  <option value="canceled" {% if bsel == 'canceled' %}selected{% endif %}>canceled</option>
+                </select>
+              </div>
               <div>
                 <label class="block text-xs font-medium text-gray-700">Serial Number</label>
                 <input id="ovw-serialnumber" type="text" value="{{ entity.get('serialnumber','') }}" class="mt-1 w-full border border-gray-300 rounded-md px-3 py-2 font-mono">
@@ -615,6 +641,7 @@ function getOverviewCurrentState(){
   const policy = document.getElementById('ovw-policy')?.value || '';
   const uom = document.getElementById('ovw-uom')?.value || '';
   const tags = document.getElementById('ovw-tags')?.value || '';
+  const status = document.getElementById('ovw-status')?.value || '';
   const serialnumber = document.getElementById('ovw-serialnumber')?.value || '';
   const datetime = document.getElementById('ovw-builtat')?.value || '';
   const list = document.getElementById('ovw-attrs-editor-list');
@@ -628,8 +655,29 @@ function getOverviewCurrentState(){
       if(k){ attrs[k] = v; }
     }
   });
-  return { name, description, notes, category, policy, uom, tags, attrs, serialnumber, datetime };
+  return { name, description, notes, category, policy, uom, tags, attrs, status, serialnumber, datetime };
 }
+
+function ovwSetBuildStatusBadge(el, raw){
+  if(!el) return;
+  const status = String(raw || '').trim().toLowerCase();
+  el.textContent = status || '—';
+  el.classList.remove(
+    'bg-green-100','text-green-800',
+    'bg-blue-100','text-blue-800',
+    'bg-red-100','text-red-800',
+    'bg-amber-100','text-amber-800',
+    'bg-gray-100','text-gray-700','inline-flex','items-center',
+    'px-2.5','py-0.5','rounded-full','text-sm','font-medium'
+  );
+  el.classList.add('inline-flex','items-center','px-2.5','py-0.5','rounded-full','text-sm','font-medium');
+  if(status === 'completed') el.classList.add('bg-green-100','text-green-800');
+  else if(status === 'in_progress') el.classList.add('bg-blue-100','text-blue-800');
+  else if(status === 'canceled') el.classList.add('bg-red-100','text-red-800');
+  else if(status === 'open') el.classList.add('bg-amber-100','text-amber-800');
+  else el.classList.add('bg-gray-100','text-gray-700');
+}
+
 function toggleOverviewMode(){
   const disp = document.getElementById('overview-display');
   const ed = document.getElementById('overview-editor');
@@ -699,8 +747,10 @@ async function saveOverview(){
   const policy = document.getElementById('ovw-policy').value;
   const uom = document.getElementById('ovw-uom').value;
   const tags = document.getElementById('ovw-tags').value;
+  const statusEl = document.getElementById('ovw-status');
   const serialnumberEl = document.getElementById('ovw-serialnumber');
   const builtAtEl = document.getElementById('ovw-builtat');
+  const status = statusEl ? (statusEl.value || '').trim() : undefined;
   const serialnumber = serialnumberEl ? serialnumberEl.value : undefined;
   const datetime = builtAtEl ? builtAtEl.value : undefined;
   const err = document.getElementById('ovw-error');
@@ -719,6 +769,7 @@ async function saveOverview(){
       }
     });
     const updates = { name, description, notes, category, policy, uom, tags, attrs };
+    if(status !== undefined) updates.status = status || null;
     if(serialnumber !== undefined) updates.serialnumber = serialnumber;
     if(datetime !== undefined) updates.datetime = datetime;
     const res = await fetch(`/api/entities/${encodeURIComponent(SFID)}/update`, {
@@ -735,6 +786,11 @@ async function saveOverview(){
     setText('ovw-notes-display', notes||'');
     setText('ovw-category-display', category||'');
     // Build fields
+    if(status !== undefined){
+      const statusBadge = document.getElementById('ovw-status-display');
+      if(statusBadge) ovwSetBuildStatusBadge(statusBadge, status);
+      else needReload = true;
+    }
     if(serialnumber !== undefined) setText('ovw-serialnumber-display', serialnumber || '—');
     if(datetime !== undefined) setText('ovw-builtat-display', datetime || '—');
     // Policy badge

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -281,7 +281,13 @@
                     <tr class="hover:bg-gray-50">
                         <td class="px-6 py-4 text-sm text-gray-900 break-words">{{ b.name }}</td>
                         <td class="px-6 py-4 text-sm">
-                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ 'bg-green-100 text-green-800' if b.status == 'closed' else 'bg-yellow-100 text-yellow-800' }}">{{ b.status }}</span>
+                            {% set st = (b.status or 'unknown') %}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
+                                {{ 'bg-green-100 text-green-800' if st == 'completed' else
+                                   'bg-blue-100 text-blue-800' if st == 'in_progress' else
+                                   'bg-red-100 text-red-800' if st == 'canceled' else
+                                   'bg-amber-100 text-amber-800' if st == 'open' else
+                                   'bg-gray-100 text-gray-800' }}">{{ st }}</span>
                         </td>
                         <td class="px-6 py-4 text-sm text-gray-500">{{ b.opened_at or '—' }}</td>
                         <td class="px-6 py-4 text-sm text-gray-500">{{ b.closed_at or '—' }}</td>


### PR DESCRIPTION
## Summary
- expose build status in the entity overview and inline editor
- show build lifecycle status on build lists and recent builds instead of generic entity state
- add route and API coverage for build status rendering and updates

## Testing
- pytest -q tests/test_web_route_smoke.py tests/test_web_entity_crud.py