### PR TITLE
Add operations dashboard and build stock checks

### DIFF
--- a/smallfactory/core/v1/entities.py
+++ b/smallfactory/core/v1/entities.py
@@ -610,7 +610,7 @@ def _build_bom_tree_nodes(
         if max_depth is not None and level > max_depth:
             return
         lines = _bom_list_at_rev(parent_sfid, parent_rev)
-        for line in lines or []:
+        for line_index, line in enumerate(lines or []):
             if not isinstance(line, dict):
                 continue
             child = str(line.get("use", "")).strip()
@@ -632,6 +632,7 @@ def _build_bom_tree_nodes(
                 "rev_spec": rev_spec,
                 "rev": child_resolved_rev,
                 "level": level,
+                "bom_index": line_index,
                 "is_alt": False,
                 "alternates_group": alt_group,
                 "gross_qty": cum,
@@ -653,6 +654,7 @@ def _build_bom_tree_nodes(
                     "rev_spec": rev_spec,
                     "rev": alt_resolved_rev,
                     "level": level,
+                    "bom_index": line_index,
                     "is_alt": True,
                     "alternates_group": alt_group,
                     "gross_qty": cum,
@@ -717,6 +719,7 @@ def resolved_bom_view(
                 "rev": n.get("rev_spec", "released"),
                 "resolved_rev": n.get("rev"),
                 "level": base_level + int(level_offset or 0),
+                "bom_index": n.get("bom_index"),
                 "is_alt": n.get("is_alt", False),
                 "alternates_group": n.get("alternates_group"),
                 "gross_qty": n.get("gross_qty"),

--- a/tests/test_web_route_smoke.py
+++ b/tests/test_web_route_smoke.py
@@ -6,7 +6,8 @@ import pytest
 from jinja2 import FileSystemLoader
 
 from conftest import import_web_app_module, init_git_repo
-from smallfactory.core.v1.entities import bom_add_line, create_entity
+from smallfactory.core.v1.entities import bom_add_line, bom_alt_add, create_entity
+from smallfactory.core.v1.inventory import inventory_post
 from smallfactory.core.v1.repo import write_datarepo_config
 
 pytest.importorskip("flask", reason="Flask not installed; web route tests skipped")
@@ -121,3 +122,80 @@ def test_builds_list_shows_build_status_not_entity_state(client):
     assert "Build Open" in body
     assert "open" in body
     assert "Active" not in body
+
+
+def test_build_readiness_api_returns_shortage_summary(client):
+    resp = client.get("/api/entities/p_widget/build-readiness?build_qty=2")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    readiness = data["readiness"]
+    assert readiness["build_qty"] == 2
+    assert readiness["shortage_count"] >= 0
+    assert readiness["missing_revision_count"] == 0
+
+
+def test_build_readiness_api_rejects_missing_and_non_part_entities(client):
+    missing = client.get("/api/entities/p_missing/build-readiness")
+    non_part = client.get("/api/entities/b_test_001/build-readiness")
+
+    assert missing.status_code == 404
+    assert missing.get_json()["success"] is False
+    assert non_part.status_code == 400
+    assert non_part.get_json()["success"] is False
+
+
+def test_build_readiness_counts_stocked_alternate(client):
+    create_entity(client._repo, "p_alt_child", {"name": "Alternate Child"})
+    create_entity(client._repo, "l_main", {"name": "Main Stock"})
+    bom_alt_add(client._repo, "p_widget", index=0, alt_use="p_alt_child")
+    inventory_post(client._repo, "p_alt_child", 1, l_sfid="l_main")
+
+    resp = client.get("/api/entities/p_widget/build-readiness")
+
+    assert resp.status_code == 200
+    readiness = resp.get_json()["readiness"]
+    assert readiness["can_build_qty"] >= 1
+    assert readiness["shortage_count"] == 0
+    assert readiness["rows"][0]["covered_by_alternate"] is True
+
+
+def test_revision_manifest_endpoint_returns_artifact_summary(client):
+    # Create a released snapshot so the manifest endpoint has revision metadata.
+    mod = import_web_app_module()
+    mod.bump_revision(client._repo, "p_child", rev="1")
+    mod.release_revision(client._repo, "p_child", "1")
+
+    resp = client.get("/api/entities/p_child/revisions/1/manifest")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert data["manifest"]["rev"] == "1"
+    assert data["manifest"]["artifact_count"] >= 1
+
+
+def test_revision_manifest_endpoint_scans_legacy_snapshot_files(client):
+    rev_dir = client._repo / "entities" / "p_child" / "revisions" / "legacy"
+    rev_dir.mkdir(parents=True)
+    (rev_dir / "meta.yml").write_text("rev: legacy\nstatus: released\n", encoding="utf-8")
+    (rev_dir / "entity.yml").write_text("name: Legacy Child\n", encoding="utf-8")
+
+    resp = client.get("/api/entities/p_child/revisions/legacy/manifest")
+
+    assert resp.status_code == 200
+    manifest = resp.get_json()["manifest"]
+    assert manifest["artifact_count"] >= 1
+    assert any(a["path"] == "entity.yml" for a in manifest["artifacts"])
+
+
+def test_entity_revision_table_includes_manifest_ui(client):
+    resp = client.get("/entities/p_child")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Source" in body
+    assert "Files" in body
+    assert "View manifest" in body
+    assert "/api/entities/${encodeURIComponent(SFID)}/revisions/${encodeURIComponent(id)}/manifest" in body

--- a/tests/test_web_route_smoke.py
+++ b/tests/test_web_route_smoke.py
@@ -34,6 +34,7 @@ def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
 
     with mod.app.test_client() as client:
         client._repo = repo
+        client._web_mod = mod
         yield client
 
 
@@ -159,6 +160,22 @@ def test_build_readiness_counts_stocked_alternate(client):
     assert readiness["can_build_qty"] >= 1
     assert readiness["shortage_count"] == 0
     assert readiness["rows"][0]["covered_by_alternate"] is True
+
+
+def test_build_readiness_api_hides_internal_exception_details(client, monkeypatch):
+    def fail(*args, **kwargs):
+        raise RuntimeError("internal stack detail /tmp/secret")
+
+    monkeypatch.setattr(client._web_mod, "ent_resolved_bom_view", fail)
+
+    resp = client.get("/api/entities/p_widget/build-readiness")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    readiness = resp.get_json()["readiness"]
+    assert readiness["error"] == "Unable to compute build stock check."
+    assert "internal stack detail" not in body
+    assert "/tmp/secret" not in body
 
 
 def test_revision_manifest_endpoint_returns_artifact_summary(client):

--- a/web/app.py
+++ b/web/app.py
@@ -23,6 +23,8 @@ import time
 import atexit
 from contextlib import contextmanager, nullcontext
 import tarfile
+import math
+import hashlib
 from jinja2 import ChoiceLoader, FileSystemLoader
 
 # Prometheus metrics
@@ -1406,6 +1408,299 @@ def compute_dashboard_metrics(datarepo_path: Path, *, top_n: int = 5) -> dict:
     }
     return metrics
 
+
+def _coerce_int(value, default=0) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return int(default)
+
+
+def _entity_lookup(entity: dict, *names: str):
+    """Read a field from top-level entity data or attrs aliases."""
+    attrs = entity.get('attrs') if isinstance(entity.get('attrs'), dict) else {}
+    for name in names:
+        if name in entity and entity.get(name) not in (None, ''):
+            return entity.get(name)
+        if name in attrs and attrs.get(name) not in (None, ''):
+            return attrs.get(name)
+    return None
+
+
+def _stock_bucket(total: int, reorder_min: int | None = None) -> str:
+    if reorder_min is not None and reorder_min > 0:
+        if total <= 0:
+            return 'critical'
+        if total < reorder_min:
+            return 'low'
+        return 'ok'
+    if total <= 0:
+        return 'critical'
+    if total <= 5:
+        return 'low'
+    return 'ok'
+
+
+def _all_part_inventory_rows(datarepo_path: Path) -> list[dict]:
+    summary = inventory_onhand_readonly(datarepo_path) or {}
+    summary_parts = summary.get('parts', []) if isinstance(summary, dict) else []
+    summary_by_sfid = {p.get('sfid'): p for p in summary_parts if isinstance(p, dict) and p.get('sfid')}
+    entities = list_entities(datarepo_path) or []
+    parts = [e for e in entities if str(e.get('sfid', '')).startswith('p_')]
+    rows = []
+    for ent in parts:
+        sfid = ent.get('sfid')
+        inv = summary_by_sfid.get(sfid) or {}
+        total = _coerce_int(inv.get('total'), 0)
+        reorder_raw = _entity_lookup(ent, 'reorder_min', 'min_stock', 'reorder_point')
+        reorder_min = None
+        if reorder_raw not in (None, ''):
+            reorder_min = max(0, _coerce_int(reorder_raw, 0))
+        vendor = _entity_lookup(ent, 'vendor', 'supplier', 'supplier_name')
+        mpn = _entity_lookup(ent, 'mpn', 'mfr_pn', 'manufacturer_part', 'manufacturer part')
+        manufacturer = _entity_lookup(ent, 'manufacturer', 'mfr')
+        bucket = _stock_bucket(total, reorder_min)
+        suggested_target = int(reorder_min) if reorder_min is not None and reorder_min > 0 else (5 if bucket in ('critical', 'low') else total)
+        rows.append({
+            'sfid': sfid,
+            'name': ent.get('name') or sfid,
+            'uom': inv.get('uom') or ent.get('uom') or 'ea',
+            'total': total,
+            'by_location': inv.get('by_location', {}) if isinstance(inv.get('by_location'), dict) else {},
+            'reorder_min': reorder_min,
+            'status_bucket': bucket,
+            'policy': str(ent.get('policy') or '').lower(),
+            'vendor': vendor,
+            'manufacturer': manufacturer,
+            'mpn': mpn,
+            'short_to_min': max(0, int(reorder_min or 0) - total),
+            'suggested_order_qty': max(0, int(suggested_target) - total),
+        })
+    return rows
+
+
+def compute_operational_report(datarepo_path: Path, *, top_n: int = 25) -> dict:
+    """Read-only operations dashboard view model."""
+    metrics = compute_dashboard_metrics(datarepo_path, top_n=5)
+    rows = _all_part_inventory_rows(datarepo_path)
+    low_rows = [r for r in rows if r['status_bucket'] in ('critical', 'low')]
+    purchase_rows = [
+        r for r in low_rows
+        if r.get('policy') == 'buy' or r.get('vendor') or r.get('mpn') or r.get('manufacturer')
+    ]
+    purchase_rows = [r for r in purchase_rows if int(r.get('suggested_order_qty', 0) or 0) > 0]
+    purchase_rows.sort(key=lambda r: (0 if r['status_bucket'] == 'critical' else 1, -r.get('short_to_min', 0), r.get('sfid') or ''))
+    low_rows.sort(key=lambda r: (0 if r['status_bucket'] == 'critical' else 1, r.get('total', 0), r.get('sfid') or ''))
+
+    missing_metadata = []
+    for row in rows:
+        missing = []
+        if not row.get('name'):
+            missing.append('name')
+        if not row.get('mpn'):
+            missing.append('mpn')
+        if not row.get('vendor') and not row.get('manufacturer'):
+            missing.append('supplier/manufacturer')
+        if missing:
+            missing_metadata.append({'sfid': row.get('sfid'), 'name': row.get('name'), 'missing': missing})
+
+    try:
+        validation = validate_repo(datarepo_path, include_entities=True, include_inventory=True, include_git=False)
+    except Exception as exc:
+        validation = {'errors': 0, 'warnings': 0, 'issues': [], 'error': str(exc)}
+
+    return {
+        'metrics': metrics,
+        'parts_count': len(rows),
+        'critical_count': sum(1 for r in rows if r['status_bucket'] == 'critical'),
+        'low_count': sum(1 for r in rows if r['status_bucket'] == 'low'),
+        'ok_count': sum(1 for r in rows if r['status_bucket'] == 'ok'),
+        'low_stock': low_rows[:top_n],
+        'purchase_rows': purchase_rows[:top_n],
+        'missing_metadata': missing_metadata[:top_n],
+        'validation': validation,
+    }
+
+
+def compute_build_readiness(datarepo_path: Path, sfid: str, *, build_qty: int = 1, location_sfid: str | None = None) -> dict:
+    """Read-only BOM shortage/kitting summary for a candidate build."""
+    build_qty = max(1, min(_coerce_int(build_qty, 1), 100000))
+    location_sfid = (location_sfid or '').strip() or None
+    rows = []
+    try:
+        nodes = ent_resolved_bom_view(datarepo_path, sfid, max_depth=None, level_offset=1)
+    except Exception as exc:
+        return {
+            'sfid': sfid,
+            'build_qty': build_qty,
+            'location_sfid': location_sfid,
+            'can_build_qty': 0,
+            'shortage_count': 0,
+            'missing_revision_count': 1,
+            'rows': [],
+            'error': str(exc),
+        }
+
+    def _node_required_each(node: dict) -> int:
+        gross = node.get('gross_qty')
+        return _coerce_int(gross if gross not in (None, '') else node.get('qty'), 0)
+
+    def _stock_snapshot(part_sfid: str) -> tuple[int, dict]:
+        try:
+            inv = inventory_onhand_readonly(datarepo_path, part=part_sfid) or {}
+            by_loc = inv.get('by_location', {}) if isinstance(inv.get('by_location'), dict) else {}
+            total = _coerce_int(by_loc.get(location_sfid), 0) if location_sfid else _coerce_int(inv.get('total'), 0)
+            return total, by_loc
+        except Exception:
+            return 0, {}
+
+    def _requires_released_revision(part_sfid: str, resolved_rev) -> bool:
+        if resolved_rev:
+            return False
+        try:
+            return bool(bom_list(datarepo_path, part_sfid))
+        except Exception:
+            return False
+
+    grouped: dict[tuple, list[dict]] = {}
+    alternates_count = 0
+    for node in nodes:
+        use = node.get('use')
+        if not isinstance(use, str) or not use.startswith('p_'):
+            continue
+        required_each = _node_required_each(node)
+        if required_each <= 0:
+            continue
+        if node.get('is_alt'):
+            alternates_count += 1
+        group_key = (
+            node.get('parent'),
+            node.get('bom_index'),
+            node.get('alternates_group'),
+            node.get('level'),
+            required_each,
+        )
+        onhand, by_location = _stock_snapshot(use)
+        required_total = required_each * build_qty
+        shortage = max(0, int(required_total) - int(onhand))
+        can_build_qty = int(math.floor(int(onhand) / int(required_each))) if required_each > 0 else None
+        grouped.setdefault(group_key, []).append({
+            'sfid': use,
+            'name': node.get('name') or use,
+            'rev': node.get('rev') or 'released',
+            'resolved_rev': node.get('resolved_rev'),
+            'required_each': required_each,
+            'required_total': required_total,
+            'onhand': onhand,
+            'by_location': by_location,
+            'shortage': shortage,
+            'can_build_qty': can_build_qty,
+            'is_alt': bool(node.get('is_alt')),
+            'missing_revision': _requires_released_revision(use, node.get('resolved_rev')),
+        })
+
+    missing_revisions = []
+    for candidates in grouped.values():
+        primary = next((c for c in candidates if not c.get('is_alt')), candidates[0])
+        best = max(
+            candidates,
+            key=lambda c: (
+                _coerce_int(c.get('can_build_qty'), 0),
+                -_coerce_int(c.get('shortage'), 0),
+                0 if not c.get('is_alt') else 1,
+            ),
+        )
+        entry = dict(primary)
+        if best is not primary:
+            entry.update({
+                'stock_sfid': best.get('sfid'),
+                'stock_name': best.get('name'),
+                'onhand': best.get('onhand'),
+                'by_location': best.get('by_location'),
+                'shortage': best.get('shortage'),
+                'can_build_qty': best.get('can_build_qty'),
+                'covered_by_alternate': best.get('shortage', 0) < primary.get('shortage', 0),
+            })
+        entry['alternates'] = [c for c in candidates if c.get('is_alt')]
+        if entry.get('missing_revision'):
+            missing_revisions.append(entry.get('sfid'))
+        rows.append(entry)
+
+    rows.sort(key=lambda r: (-int(r.get('shortage', 0)), r.get('sfid') or ''))
+    finite_can_build = [r['can_build_qty'] for r in rows if r.get('can_build_qty') is not None]
+    can_build_qty = min(finite_can_build) if finite_can_build else 0
+    return {
+        'sfid': sfid,
+        'build_qty': build_qty,
+        'location_sfid': location_sfid,
+        'can_build_qty': can_build_qty,
+        'shortage_count': sum(1 for r in rows if int(r.get('shortage', 0)) > 0),
+        'missing_revision_count': len(set(missing_revisions)),
+        'rows': rows,
+        'alternates_count': alternates_count,
+    }
+
+
+def _revision_artifacts_from_snapshot(datarepo_path: Path, sfid: str, rev: str) -> list[dict]:
+    rev_dir = datarepo_path / 'entities' / sfid / 'revisions' / str(rev)
+    if not rev_dir.exists() or not rev_dir.is_dir():
+        return []
+    artifacts = []
+    for path in sorted(rev_dir.rglob('*')):
+        if not path.is_file() or path.name in {'meta.yml', '.gitkeep'}:
+            continue
+        rel = path.relative_to(rev_dir)
+        rel_str = str(rel).replace('\\', '/')
+        role = 'file'
+        if rel_str == 'entity.yml':
+            role = 'entity'
+        elif rel_str == 'bom_tree.yml':
+            role = 'bom-tree'
+        elif rel.parts and rel.parts[0] == 'refs':
+            role = 'ref'
+        suffix = path.suffix.lower()
+        if role == 'file':
+            if suffix in {'.step', '.stp', '.iges', '.igs', '.stl', '.dxf', '.dwg', '.3mf', '.obj'}:
+                role = 'cad-export'
+            elif suffix in {'.pdf', '.svg'}:
+                role = 'drawing'
+            elif suffix in {'.png', '.jpg', '.jpeg', '.gif', '.bmp', '.tif', '.tiff'}:
+                role = 'image'
+            elif suffix in {'.md', '.txt'}:
+                role = 'doc'
+        artifact = {'role': role, 'path': rel_str}
+        try:
+            h = hashlib.sha256()
+            with path.open('rb') as f:
+                for chunk in iter(lambda: f.read(8192), b''):
+                    h.update(chunk)
+            artifact['sha256'] = h.hexdigest()
+        except Exception:
+            pass
+        artifacts.append(artifact)
+    return artifacts
+
+
+def get_revision_manifest(datarepo_path: Path, sfid: str, rev: str) -> dict:
+    info = get_revisions(datarepo_path, sfid) or {}
+    revisions = info.get('revisions') if isinstance(info.get('revisions'), list) else []
+    for item in revisions:
+        if str(item.get('id') or item.get('rev') or '') == str(rev):
+            artifacts = item.get('artifacts') if isinstance(item.get('artifacts'), list) else []
+            if not artifacts:
+                artifacts = _revision_artifacts_from_snapshot(datarepo_path, sfid, rev)
+            return {
+                'sfid': sfid,
+                'rev': rev,
+                'status': item.get('status'),
+                'created_at': item.get('created_at') or item.get('generated_at'),
+                'released_at': item.get('released_at'),
+                'source_commit': item.get('source_commit'),
+                'artifact_count': len(artifacts),
+                'artifacts': artifacts,
+            }
+    raise FileNotFoundError(f"Revision '{rev}' not found for {sfid}")
+
 # -----------------------
 # Repository stats and validation
 # -----------------------
@@ -1597,13 +1892,16 @@ def index():
     try:
         datarepo_path = get_datarepo_path()
         metrics = compute_dashboard_metrics(datarepo_path, top_n=5)
+        report = compute_operational_report(datarepo_path, top_n=5)
         return render_template(
             'index.html',
             metrics=metrics,
+            report=report,
             datarepo_path=str(datarepo_path)
         )
     except Exception as e:
         return render_template('error.html', error=str(e))
+
 
 @app.route('/vision', methods=['GET'])
 def vision_page():
@@ -2002,9 +2300,17 @@ def entities_build(sfid):
                 flash(f"Failed to create build record: {e}", 'error')
                 return redirect(url_for('entities_build', sfid=sfid))
 
-        # GET: show form and optional preview if qty provided
+        # GET: show form plus a read-only stock check for one finished unit.
         l_sfid = (request.args.get('l_sfid') or '').strip()
         notes = (request.args.get('notes') or '').strip()
+        readiness_qty = 1
+        readiness_location = ''
+        readiness = compute_build_readiness(
+            datarepo_path,
+            sfid,
+            build_qty=readiness_qty,
+            location_sfid=readiness_location or None,
+        ) if is_part else None
         rev_selected = (request.args.get('rev') or ('released' if released_rev else '')).strip()
         # If no released pointer and no explicit selection, default to the latest revision id
         if not rev_selected and revisions:
@@ -2023,6 +2329,9 @@ def entities_build(sfid):
             l_sfid=l_sfid,
             notes=notes,
             rev_selected=rev_selected,
+            readiness=readiness,
+            readiness_qty=readiness_qty,
+            readiness_location=readiness_location,
             can_build=can_build,
             is_part=is_part,
         )
@@ -2624,6 +2933,31 @@ def api_revisions_get(sfid):
         return jsonify({'success': True, 'rev': info.get('rev'), 'revisions': info.get('revisions', [])})
     except Exception as e:
         return _api_exception_response(e, 400)
+
+
+@app.route('/api/entities/<sfid>/build-readiness', methods=['GET'])
+def api_build_readiness(sfid):
+    try:
+        datarepo_path = get_datarepo_path()
+        get_entity(datarepo_path, sfid)
+        if not str(sfid).startswith('p_'):
+            raise ValueError("Build readiness is only available for part entities ('p_*')")
+        build_qty = _coerce_int(request.args.get('build_qty'), 1)
+        location_sfid = (request.args.get('location_sfid') or '').strip() or None
+        return jsonify({'success': True, 'readiness': compute_build_readiness(datarepo_path, sfid, build_qty=build_qty, location_sfid=location_sfid)})
+    except FileNotFoundError as e:
+        return _api_exception_response(e, 404)
+    except Exception as e:
+        return _api_exception_response(e, 400)
+
+
+@app.route('/api/entities/<sfid>/revisions/<rev>/manifest', methods=['GET'])
+def api_revisions_manifest(sfid, rev):
+    try:
+        datarepo_path = get_datarepo_path()
+        return jsonify({'success': True, 'manifest': get_revision_manifest(datarepo_path, sfid, rev)})
+    except Exception as e:
+        return _api_exception_response(e, 404)
 
 @app.route('/api/entities/<sfid>/revisions/bump', methods=['POST'])
 def api_revisions_bump(sfid):

--- a/web/app.py
+++ b/web/app.py
@@ -1530,6 +1530,10 @@ def compute_build_readiness(datarepo_path: Path, sfid: str, *, build_qty: int = 
     try:
         nodes = ent_resolved_bom_view(datarepo_path, sfid, max_depth=None, level_offset=1)
     except Exception as exc:
+        try:
+            app.logger.exception("Failed to compute build stock check for %s: %s", sfid, exc)
+        except Exception:
+            pass
         return {
             'sfid': sfid,
             'build_qty': build_qty,
@@ -1538,7 +1542,7 @@ def compute_build_readiness(datarepo_path: Path, sfid: str, *, build_qty: int = 
             'shortage_count': 0,
             'missing_revision_count': 1,
             'rows': [],
-            'error': str(exc),
+            'error': 'Unable to compute build stock check.',
         }
 
     def _node_required_each(node: dict) -> int:

--- a/web/templates/entities/build.html
+++ b/web/templates/entities/build.html
@@ -120,7 +120,81 @@
         </div>
       </div>
 
-      <!-- No preview/backflush in simplified flow -->
+      <div class="bg-white rounded-lg shadow-sm border border-gray-200 mt-6">
+        <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+          <h2 class="text-lg font-semibold text-gray-900"><i class="fas fa-clipboard-check mr-2 text-blue-600"></i>Build Stock Check</h2>
+          {% if readiness and readiness.error %}
+          <span class="px-2 py-0.5 rounded-full text-xs font-medium bg-rose-100 text-rose-800">Needs attention</span>
+          {% elif readiness and readiness.shortage_count == 0 and readiness.missing_revision_count == 0 %}
+          <span class="px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Ready</span>
+          {% elif readiness and readiness.missing_revision_count > 0 %}
+          <span class="px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">Missing revisions</span>
+          {% else %}
+          <span class="px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">Shortages</span>
+          {% endif %}
+        </div>
+        <div class="px-6 py-5">
+          <p class="mb-4 text-sm text-gray-600">Checks whether there is enough stock to build one finished unit of this part, counting inventory across all locations. This does not create a build record or change inventory.</p>
+
+          {% if readiness and readiness.error %}
+          <div class="bg-rose-50 border border-rose-200 text-rose-800 px-4 py-3 rounded text-sm">{{ readiness.error }}</div>
+          {% elif readiness %}
+          <div class="grid grid-cols-1 sm:grid-cols-4 gap-4 mb-5">
+            <div class="rounded-lg bg-gray-50 p-4">
+              <div class="text-xs uppercase tracking-wide text-gray-500">Finished units possible</div>
+              <div class="mt-1 text-2xl font-bold text-gray-900">{{ readiness.can_build_qty }}</div>
+            </div>
+            <div class="rounded-lg bg-gray-50 p-4">
+              <div class="text-xs uppercase tracking-wide text-gray-500">Finished unit checked</div>
+              <div class="mt-1 text-2xl font-bold text-gray-900">{{ readiness.build_qty }}</div>
+            </div>
+            <div class="rounded-lg bg-gray-50 p-4">
+              <div class="text-xs uppercase tracking-wide text-gray-500">Short items</div>
+              <div class="mt-1 text-2xl font-bold {{ 'text-rose-700' if readiness.shortage_count else 'text-green-700' }}">{{ readiness.shortage_count }}</div>
+            </div>
+            <div class="rounded-lg bg-gray-50 p-4">
+              <div class="text-xs uppercase tracking-wide text-gray-500">Alternates</div>
+              <div class="mt-1 text-2xl font-bold text-gray-900">{{ readiness.alternates_count }}</div>
+            </div>
+          </div>
+
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 text-sm">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Part</th>
+                  <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">Need each</th>
+                  <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">Need total</th>
+                  <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">On hand</th>
+                  <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">Short</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                {% for row in readiness.rows %}
+                <tr class="{{ 'bg-rose-50' if row.shortage else 'odd:bg-gray-50' }}">
+                  <td class="px-3 py-2">
+                    <a class="font-mono text-blue-700 hover:underline" href="{{ url_for('entities_view', sfid=row.sfid) }}">{{ row.sfid }}</a>
+                    <div class="text-xs text-gray-500">{{ row.name }}</div>
+                    {% if row.covered_by_alternate %}
+                    <div class="text-xs text-green-700">Using stocked alternate {{ row.stock_sfid }}</div>
+                    {% elif row.alternates %}
+                    <div class="text-xs text-gray-500">{{ row.alternates|length }} alternate{{ '' if row.alternates|length == 1 else 's' }} available</div>
+                    {% endif %}
+                  </td>
+                  <td class="px-3 py-2 text-right font-mono">{{ row.required_each }}</td>
+                  <td class="px-3 py-2 text-right font-mono">{{ row.required_total }}</td>
+                  <td class="px-3 py-2 text-right font-mono">{{ row.onhand }}</td>
+                  <td class="px-3 py-2 text-right font-mono {{ 'text-rose-700 font-semibold' if row.shortage else 'text-green-700' }}">{{ row.shortage }}</td>
+                </tr>
+                {% else %}
+                <tr><td colspan="5" class="px-3 py-5 text-center text-gray-500">No BOM lines to check.</td></tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% endif %}
+        </div>
+      </div>
     </div>
 
     <div class="lg:col-span-1">

--- a/web/templates/entities/view.html
+++ b/web/templates/entities/view.html
@@ -531,6 +531,8 @@
                   <th class="px-3 py-1.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-50 sticky top-0 z-10">Status</th>
                   <th class="px-3 py-1.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-50 sticky top-0 z-10">Created</th>
                   <th class="px-3 py-1.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-50 sticky top-0 z-10">Released</th>
+                  <th class="px-3 py-1.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-50 sticky top-0 z-10">Source</th>
+                  <th class="px-3 py-1.5 text-right text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-50 sticky top-0 z-10">Files</th>
                   <th class="px-3 py-1.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-50 sticky top-0 z-10">Notes</th>
                   <th class="px-3 py-1.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-50 sticky top-0 z-10">Actions</th>
                 </tr>
@@ -1344,7 +1346,7 @@ function renderRevisionsRows(list){
   tbody.innerHTML = '';
   const releases = Array.isArray(list) ? list : [];
   if(releases.length===0){
-    tbody.innerHTML = '<tr><td colspan="6" class="px-3 py-2 text-sm text-gray-500">No releases yet.</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="8" class="px-3 py-2 text-sm text-gray-500">No releases yet.</td></tr>';
     return;
   }
   releases.forEach(r => {
@@ -1353,10 +1355,15 @@ function renderRevisionsRows(list){
     const st = (r && r.released_at) ? 'released' : (r && r.status ? r.status : '—');
     const st_color = st == 'released' ? 'bg-green-100 text-green-800' : 'bg-amber-100 text-amber-800';
     const ca = r.created_at||'—';
+    const source = r.source_commit || '—';
+    const artifacts = Array.isArray(r.artifacts) ? r.artifacts.length : 0;
     const notesRaw = r.notes ? String(r.notes) : '';
     const notesHtml = notesRaw ? _nl2br(_escapeHtml(notesRaw)) : '';
     const actions = (id && id !== '—')
-      ? `<a class="text-gray-400 hover:text-blue-700" href="/api/entities/${encodeURIComponent(SFID)}/revisions/${encodeURIComponent(id)}/download" title="Download revision" aria-label="Download revision" download>
+      ? `<a class="text-gray-400 hover:text-blue-700 mr-3" href="/api/entities/${encodeURIComponent(SFID)}/revisions/${encodeURIComponent(id)}/manifest" title="View manifest" aria-label="View manifest" target="_blank" rel="noopener noreferrer">
+           <i class="fas fa-list"></i>
+         </a>
+         <a class="text-gray-400 hover:text-blue-700" href="/api/entities/${encodeURIComponent(SFID)}/revisions/${encodeURIComponent(id)}/download" title="Download revision" aria-label="Download revision" download>
            <i class="fas fa-download"></i>
          </a>`
       : '<span class="text-gray-400">—</span>';
@@ -1366,6 +1373,8 @@ function renderRevisionsRows(list){
         <td class="px-3 py-1.5"><span class="px-2 py-0.5 rounded-full text-xs ${st_color}">${st}</span></td>
         <td class="px-3 py-1.5 text-gray-700">${ca}</td>
         <td class="px-3 py-1.5 text-gray-700">${ra}</td>
+        <td class="px-3 py-1.5 text-gray-700 font-mono">${_escapeHtml(source)}</td>
+        <td class="px-3 py-1.5 text-right text-gray-700 font-mono">${artifacts}</td>
         <td class="px-3 py-1.5 text-gray-700 whitespace-pre-wrap break-words">${notesHtml || '<span class=\'text-gray-400\'>—</span>'}</td>
         <td class="px-3 py-1.5">${actions}</td>
       </tr>`);

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -5,9 +5,47 @@
 {% block content %}
 <div class="content-container">
     <!-- Header -->
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold text-gray-900">Dashboard</h1>
+    <div class="mb-8 flex items-start justify-between gap-4">
+        <div>
+            <h1 class="text-3xl font-bold text-gray-900">Operations Dashboard</h1>
+            <p class="mt-2 text-gray-600">Stockroom, reorder, build, and data-health signals from the current repo.</p>
+        </div>
+        <a href="{{ url_for('repo_stats') }}" class="inline-flex items-center px-3 py-2 rounded-md border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50">
+            <i class="fas fa-database mr-2"></i>Repo stats
+        </a>
     </div>
+
+    {% set show_first_run = metrics.parts.total == 0 or metrics.inventory.total_quantity == 0 %}
+    {% if show_first_run %}
+    <section class="bg-white rounded-lg shadow-sm border border-gray-200 mb-8">
+        <div class="px-6 py-4 border-b border-gray-200">
+            <h2 class="text-lg font-semibold text-gray-900"><i class="fas fa-route text-blue-600 mr-2"></i>Guided Setup</h2>
+        </div>
+        <div class="p-6 grid grid-cols-1 md:grid-cols-3 gap-4">
+            <a href="{{ url_for('entities_add', sfid='p_') }}" class="p-4 rounded-lg border border-gray-200 hover:bg-gray-50">
+                <div class="flex items-center justify-between">
+                    <span class="text-sm font-medium text-gray-900">Add parts</span>
+                    <span class="inline-flex h-6 w-6 items-center justify-center rounded-full {{ 'bg-green-100 text-green-700' if metrics.parts.total else 'bg-gray-100 text-gray-500' }}"><i class="fas {{ 'fa-check' if metrics.parts.total else 'fa-arrow-right' }} text-xs"></i></span>
+                </div>
+                <p class="mt-2 text-xs text-gray-500">{{ metrics.parts.total }} part{{ '' if metrics.parts.total == 1 else 's' }} in repo</p>
+            </a>
+            <a href="{{ url_for('inventory_adjust') }}" class="p-4 rounded-lg border border-gray-200 hover:bg-gray-50">
+                <div class="flex items-center justify-between">
+                    <span class="text-sm font-medium text-gray-900">Count starting stock</span>
+                    <span class="inline-flex h-6 w-6 items-center justify-center rounded-full {{ 'bg-green-100 text-green-700' if metrics.inventory.total_quantity else 'bg-gray-100 text-gray-500' }}"><i class="fas {{ 'fa-check' if metrics.inventory.total_quantity else 'fa-arrow-right' }} text-xs"></i></span>
+                </div>
+                <p class="mt-2 text-xs text-gray-500">{{ metrics.inventory.total_quantity }} total units on hand</p>
+            </a>
+            <a href="{{ url_for('stickers_index') }}" class="p-4 rounded-lg border border-gray-200 hover:bg-gray-50">
+                <div class="flex items-center justify-between">
+                    <span class="text-sm font-medium text-gray-900">Print labels</span>
+                    <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-blue-700"><i class="fas fa-qrcode text-xs"></i></span>
+                </div>
+                <p class="mt-2 text-xs text-gray-500">QR labels for parts and locations</p>
+            </a>
+        </div>
+    </section>
+    {% endif %}
 
     <!-- Stats Cards -->
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
@@ -37,181 +75,118 @@
             </div>
         </a>
 
-        <!-- Builds Total -->
-        <a href="{{ url_for('entities_list', type='b') }}" class="block bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:bg-gray-50 transition-colors">
+        <!-- Critical Stock -->
+        <a href="#operations-queue" class="block bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:bg-gray-50 transition-colors">
             <div class="flex items-center">
-                <div class="p-3 rounded-full bg-yellow-100">
-                    <i class="fas fa-industry text-yellow-600 text-xl"></i>
+                <div class="p-3 rounded-full bg-rose-100">
+                    <i class="fas fa-triangle-exclamation text-rose-600 text-xl"></i>
                 </div>
                 <div class="ml-4">
-                    <p class="text-sm font-medium text-gray-600">Builds</p>
-                    <p class="text-2xl font-bold text-gray-900">{{ metrics.builds.total }}</p>
+                    <p class="text-sm font-medium text-gray-600">Critical Stock</p>
+                    <p class="text-2xl font-bold text-gray-900">{{ report.critical_count }}</p>
                 </div>
             </div>
         </a>
 
-        <!-- Data Repository -->
+        <!-- Data Health -->
         <a href="{{ url_for('repo_stats') }}" class="block bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:bg-gray-50 transition-colors">
             <div class="flex items-center">
-                <div class="p-3 rounded-full bg-purple-100">
-                    <i class="fas fa-database text-purple-600 text-xl"></i>
+                <div class="p-3 rounded-full {{ 'bg-rose-100' if report.validation.errors else 'bg-green-100' }}">
+                    <i class="fas fa-clipboard-check {{ 'text-rose-600' if report.validation.errors else 'text-green-600' }} text-xl"></i>
                 </div>
                 <div class="ml-4">
-                    <p class="text-sm font-medium text-gray-600">Data Repository</p>
-                    <p class="text-sm font-bold text-gray-900 truncate" title="{{ datarepo_path }}">
-                        {{ datarepo_path.split('/')[-1] if '/' in datarepo_path else datarepo_path }}
-                    </p>
+                    <p class="text-sm font-medium text-gray-600">Validation Errors</p>
+                    <p class="text-2xl font-bold text-gray-900">{{ report.validation.errors }}</p>
+                    <p class="text-xs text-gray-500">{{ report.validation.warnings }} warning{{ '' if report.validation.warnings == 1 else 's' }}</p>
                 </div>
             </div>
         </a>
     </div>
 
-    <!-- Quick Actions -->
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 mb-8">
-        <div class="px-6 py-4 border-b border-gray-200 bg-gradient-to-r from-blue-50 to-blue-100">
-            <h2 class="text-lg font-semibold text-gray-900">Quick Actions</h2>
-        </div>
-        <div class="p-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            <a href="{{ url_for('inventory_adjust') }}" class="flex items-center p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors group">
-                <div class="p-2 rounded-md bg-blue-100 group-hover:bg-blue-200 transition-colors">
-                    <i class="fas fa-right-left text-blue-600"></i>
-                </div>
-                <div class="ml-3">
-                    <p class="text-sm font-medium text-gray-900">Adjust Stock</p>
-                    <p class="text-xs text-gray-500">Increase or decrease quantity</p>
-                </div>
-            </a>
-
-            <a href="{{ url_for('inventory_list') }}" class="flex items-center p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors group">
-                <div class="p-2 rounded-md bg-green-100 group-hover:bg-green-200 transition-colors">
-                    <i class="fas fa-list text-green-600"></i>
-                </div>
-                <div class="ml-3">
-                    <p class="text-sm font-medium text-gray-900">View All</p>
-                    <p class="text-xs text-gray-500">Browse inventory</p>
-                </div>
-            </a>
-
-            <a href="{{ url_for('inventory_list') }}#search" class="flex items-center p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors group">
-                <div class="p-2 rounded-md bg-yellow-100 group-hover:bg-yellow-200 transition-colors">
-                    <i class="fas fa-search text-yellow-600"></i>
-                </div>
-                <div class="ml-3">
-                    <p class="text-sm font-medium text-gray-900">Search</p>
-                    <p class="text-xs text-gray-500">Find items</p>
-                </div>
-            </a>
-
-            <div class="flex items-center p-4 border border-gray-200 rounded-lg bg-gray-50 opacity-50">
-                <div class="p-2 rounded-md bg-gray-100">
-                    <i class="fas fa-chart-bar text-gray-400"></i>
-                </div>
-                <div class="ml-3">
-                    <p class="text-sm font-medium text-gray-500">Reports</p>
-                    <p class="text-xs text-gray-400">Coming soon</p>
-                </div>
+    <!-- Operations Queue -->
+    <div id="operations-queue" class="mb-8">
+        <section class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+            <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+                <h2 class="text-lg font-semibold text-gray-900"><i class="fas fa-box-open text-amber-600 mr-2"></i>Stockroom Watchlist</h2>
+                <a class="text-sm text-blue-600 hover:text-blue-800" href="{{ url_for('inventory_list') }}">Inventory</a>
             </div>
-        </div>
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200 text-sm">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Part</th>
+                            <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">On hand</th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Supplier</th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">MPN</th>
+                            <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Order</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-100">
+                        {% for row in report.low_stock %}
+                        <tr>
+                            <td class="px-4 py-3">
+                                <a href="{{ url_for('entities_view', sfid=row.sfid) }}" class="font-medium text-blue-700 hover:underline">{{ row.name }}</a>
+                                <div class="font-mono text-xs text-gray-500">{{ row.sfid }}</div>
+                            </td>
+                            <td class="px-4 py-3 text-right font-mono">{{ row.total }} {{ row.uom }}</td>
+                            <td class="px-4 py-3">
+                                <span class="px-2 py-0.5 rounded-full text-xs font-medium {{ 'bg-rose-100 text-rose-800' if row.status_bucket == 'critical' else 'bg-amber-100 text-amber-800' }}">{{ row.status_bucket }}</span>
+                            </td>
+                            <td class="px-4 py-3 text-gray-700">{{ row.vendor or row.manufacturer or '-' }}</td>
+                            <td class="px-4 py-3 font-mono text-gray-700">{{ row.mpn or '-' }}</td>
+                            <td class="px-4 py-3 text-right font-mono">{{ row.suggested_order_qty if row.suggested_order_qty else '-' }}</td>
+                        </tr>
+                        {% else %}
+                        <tr><td colspan="6" class="px-4 py-6 text-center text-gray-500">No low-stock parts.</td></tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </section>
     </div>
 
-    <!-- Inventory Top Stock -->
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 mb-8">
-        <div class="px-6 py-4 border-b border-gray-200 bg-gradient-to-r from-blue-50 to-blue-100 flex items-center justify-between">
-            <h2 class="text-lg font-semibold text-gray-900 flex items-center"><i class="fas fa-layer-group text-blue-600 mr-2"></i>Top Stocked Parts</h2>
-            <div class="text-sm text-gray-500">
-                In stock: <span class="font-medium text-gray-900">{{ metrics.inventory.parts_with_stock }}</span>
-                · Zero stock: <span class="font-medium text-gray-900">{{ metrics.inventory.parts_zero_stock }}</span>
+    <!-- Operational Health -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+        <section class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900"><i class="fas fa-industry text-yellow-600 mr-2"></i>Build Activity</h2>
             </div>
-        </div>
-        <div class="overflow-x-auto w-full">
-            <div class="inline-block min-w-full align-middle">
-            <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
-                    <tr>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Quantity</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">UoM</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
-                    </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                    {% for item in metrics.inventory.top_stock %}
-                    <tr class="hover:bg-gray-50">
-                        <td class="px-6 py-4 text-sm text-gray-900 break-words">{{ item.name }}</td>
-                        <td class="px-6 py-4 text-sm text-gray-900">
-                            <div class="mb-1">
-                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">{{ item.total }}</span>
-                            </div>
-                        </td>
-                        <td class="px-6 py-4 text-sm text-gray-500">{{ item.uom }}</td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                            <a href="{{ url_for('inventory_view', item_id=item.sfid) }}" class="text-blue-600 hover:text-blue-900 mr-3" title="View Inventory"><i class="fas fa-eye"></i></a>
-                            <a href="{{ url_for('entities_view', sfid=item.sfid) }}" class="text-gray-600 hover:text-gray-900" title="View Entity"><i class="fas fa-id-card"></i></a>
-                        </td>
-                    </tr>
-                    {% else %}
-                    <tr>
-                        <td colspan="4" class="px-6 py-6 text-center text-sm text-gray-500">No inventory yet. <a class="text-blue-600 hover:text-blue-800" href="{{ url_for('inventory_adjust') }}">Adjust stock</a> to get started.</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-            </div>
-        </div>
-        <div class="px-6 py-3 bg-gray-50 text-right">
-            <a href="{{ url_for('inventory_list') }}" class="text-sm text-blue-600 hover:text-blue-900 font-medium">View all inventory <i class="fas fa-arrow-right ml-1"></i></a>
-        </div>
-    </div>
-
-    <!-- Parts Summary -->
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 mb-8">
-        <div class="px-6 py-4 border-b border-gray-200 bg-gradient-to-r from-green-50 to-green-100 flex items-center justify-between">
-            <h2 class="text-lg font-semibold text-gray-900 flex items-center">
-                <i class="fas fa-cubes text-green-600 mr-2"></i>
-                Parts Summary
-            </h2>
-        </div>
-        <div class="p-6">
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                <a href="{{ url_for('entities_list', type='p') }}" class="p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
-                    <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Total Parts</div>
-                    <div class="flex items-center">
-                        <div class="p-2 rounded-md bg-blue-100 mr-3"><i class="fas fa-cube text-blue-600"></i></div>
-                        <div class="text-2xl font-bold text-gray-900">{{ metrics.parts.total }}</div>
-                    </div>
+            <div class="p-6 grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <a href="{{ url_for('entities_list', type='b') }}" class="p-4 bg-gray-50 rounded-lg hover:bg-gray-100">
+                    <div class="text-xs uppercase tracking-wide text-gray-500">Builds</div>
+                    <div class="mt-1 text-2xl font-bold text-gray-900">{{ report.metrics.builds.total }}</div>
                 </a>
-                <!-- Released metrics removed per UX decision: all parts are released by default -->
-                <a href="{{ url_for('inventory_list', status='in_stock') }}" class="p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
-                    <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">In Stock</div>
-                    <div class="flex items-center">
-                        <div class="p-2 rounded-md bg-indigo-100 mr-3"><i class="fas fa-boxes-stacked text-indigo-600"></i></div>
-                        <div class="text-2xl font-bold text-gray-900">{{ metrics.inventory.parts_with_stock }}</div>
-                    </div>
-                </a>
-                <a href="{{ url_for('inventory_list', status='zero_stock') }}" class="p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
-                    <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">Zero Stock</div>
-                    <div class="flex items-center">
-                        <div class="p-2 rounded-md bg-rose-100 mr-3"><i class="fas fa-triangle-exclamation text-rose-600"></i></div>
-                        <div class="text-2xl font-bold text-gray-900">{{ metrics.inventory.parts_zero_stock }}</div>
-                    </div>
-                </a>
-            </div>
-
-            <div class="mt-6">
-                <div class="flex items-center justify-between text-sm mb-2">
-                    <span class="text-gray-600">Stock Coverage</span>
-                    <span class="font-medium text-gray-900">{{ metrics.inventory.stock_coverage_pct }}%</span>
+                <div class="p-4 bg-gray-50 rounded-lg">
+                    <div class="text-xs uppercase tracking-wide text-gray-500">Units</div>
+                    <div class="mt-1 text-2xl font-bold text-gray-900">{{ report.metrics.builds.units_built }}</div>
                 </div>
-                <div class="w-full h-2 bg-gray-200 rounded">
-                    <div class="h-2 bg-indigo-500 rounded" data-width="{{ metrics.inventory.stock_coverage_pct }}"></div>
+                <div class="p-4 bg-gray-50 rounded-lg">
+                    <div class="text-xs uppercase tracking-wide text-gray-500">Revisions</div>
+                    <div class="mt-1 text-2xl font-bold text-gray-900">{{ report.metrics.revisions.total }}</div>
                 </div>
             </div>
+        </section>
 
-            <div class="mt-6 text-right">
-                <a href="{{ url_for('entities_list', type='p') }}" class="text-sm text-blue-600 hover:text-blue-900 font-medium mr-4">View all parts <i class="fas fa-arrow-right ml-1"></i></a>
-                <a href="{{ url_for('inventory_list') }}" class="text-sm text-blue-600 hover:text-blue-900 font-medium">View inventory <i class="fas fa-arrow-right ml-1"></i></a>
+        <section class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900"><i class="fas fa-clipboard-check text-green-600 mr-2"></i>Data Health</h2>
             </div>
-        </div>
+            <div class="p-6 text-sm text-gray-700 space-y-3">
+                <div class="flex items-center justify-between">
+                    <span>Validation errors</span>
+                    <span class="font-mono font-semibold">{{ report.validation.errors }}</span>
+                </div>
+                <div class="flex items-center justify-between">
+                    <span>Validation warnings</span>
+                    <span class="font-mono font-semibold">{{ report.validation.warnings }}</span>
+                </div>
+                <div class="flex items-center justify-between">
+                    <span>Parts missing supplier/MPN signals</span>
+                    <span class="font-mono font-semibold">{{ report.missing_metadata|length }}</span>
+                </div>
+            </div>
+        </section>
     </div>
 
     <!-- Recent Revisions -->
@@ -304,22 +279,5 @@
             </table>
         </div>
     </div>
-
-    
 </div>
-{% endblock %}
-
-{% block scripts %}
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-  try {
-    document.querySelectorAll('[data-width]').forEach(function (el) {
-      var pct = parseInt(el.getAttribute('data-width'), 10);
-      if (isNaN(pct)) pct = 0;
-      pct = Math.max(0, Math.min(100, pct));
-      el.style.width = pct + '%';
-    });
-  } catch (e) { console && console.error && console.error(e); }
-});
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- consolidate dashboard/reporting into one operations dashboard with stockroom, reorder, build activity, and data-health signals
- add read-only build stock checks and manifest/source/file visibility for revisions
- preserve compatibility for BOM traversal, legacy revision snapshots, and new API error behavior

## Verification
- venv/bin/python -m py_compile web/app.py smallfactory/core/v1/entities.py
- venv/bin/python -m pytest

Result: 422 passed, 1 skipped
