### PR TITLE
Fix stack trace exposure alert

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -47,11 +47,25 @@ ensure_config_file() {
     return
   fi
 
-  if grep -q '^default_datarepo:' "$config_file"; then
-    sed -i "s#^default_datarepo:.*#default_datarepo: ${SF_REPO_PATH//#/\\#}#" "$config_file"
-  else
-    printf "default_datarepo: %s\n" "$SF_REPO_PATH" >> "$config_file"
-  fi
+  local tmp_file
+  tmp_file="${config_file}.$$"
+  awk -v repo="$SF_REPO_PATH" '
+    BEGIN { updated = 0 }
+    /^default_datarepo:/ {
+      if (!updated) {
+        print "default_datarepo: " repo
+        updated = 1
+      }
+      next
+    }
+    { print }
+    END {
+      if (!updated) {
+        print "default_datarepo: " repo
+      }
+    }
+  ' "$config_file" > "$tmp_file"
+  mv "$tmp_file" "$config_file"
 }
 
 configure_git() {

--- a/tests/test_api_error_sanitization.py
+++ b/tests/test_api_error_sanitization.py
@@ -1,8 +1,8 @@
 """Regression tests for _api_exception_response sanitization.
 
 Verifies that:
-- Expected validation exceptions (ValueError, KeyError, etc.) surface concise
-  messages in default 4xx responses.
+- Expected validation exceptions (ValueError, KeyError, etc.) surface fixed
+  public messages in default 4xx responses without reflecting exception text.
 - Unexpected / internal exceptions (RuntimeError, OSError, PermissionError,
   generic Exception) are redacted to a generic message.
 - 5xx responses never leak exception details regardless of type.
@@ -37,24 +37,30 @@ def _call(mod, exc, status=400, public_message="Request failed", hint=None):
 
 
 # ---------------------------------------------------------------------------
-# Safe validation exceptions SHOULD surface in default 4xx responses
+# Safe validation exceptions SHOULD surface fixed public messages
 # ---------------------------------------------------------------------------
 
 class TestSafeTypesExposed:
 
-    @pytest.mark.parametrize("exc", [
-        ValueError("Invalid SFID format"),
-        KeyError("missing_field"),
-        IndexError("BOM line 99 out of range"),
-        FileNotFoundError("Entity p_ghost not found"),
-        FileExistsError("Entity p_dup already exists"),
+    @pytest.mark.parametrize(("exc", "expected"), [
+        (ValueError("Invalid SFID format /var/secrets/token"), "Invalid request"),
+        (KeyError("missing_field /var/secrets/token"), "Invalid request"),
+        (IndexError("BOM line 99 out of range /var/secrets/token"), "Invalid request"),
+        (
+            FileNotFoundError("Entity p_ghost not found /var/secrets/token"),
+            "Requested resource was not found",
+        ),
+        (
+            FileExistsError("Entity p_dup already exists /var/secrets/token"),
+            "Requested resource already exists",
+        ),
     ])
-    def test_validation_error_surfaces_in_400(self, _app, exc):
+    def test_validation_error_surfaces_in_400(self, _app, exc, expected):
         data, code = _call(_app, exc, status=400)
         assert code == 400
         assert data["success"] is False
-        assert data["error"] != "Request failed"
-        assert len(data["error"]) > 0
+        assert data["error"] == expected
+        assert "/var/secrets" not in data["error"]
 
 
 # ---------------------------------------------------------------------------
@@ -108,10 +114,11 @@ class TestUnsafeTypesRedacted:
         assert code == 400
         assert data["error"] == "Another SmallFactory operation is in progress; retry shortly."
 
-    def test_safe_exception_multiline_truncated(self, _app):
+    def test_safe_exception_multiline_redacted(self, _app):
         exc = ValueError("first line\nsecond line with /secret/path")
         data, _ = _call(_app, exc, status=400)
-        assert data["error"] == "first line"
+        assert data["error"] == "Invalid request"
+        assert "first line" not in data["error"]
         assert "second line" not in data["error"]
 
 

--- a/web/app.py
+++ b/web/app.py
@@ -101,16 +101,21 @@ def _api_exception_response(
             return "Another SmallFactory operation is in progress; retry shortly."
         return None
 
-    # Surface concise validation feedback for known user-input exceptions only.
-    _SAFE_EXC_TYPES = (ValueError, KeyError, IndexError, FileNotFoundError, FileExistsError)
+    def _default_public_message(err: Exception) -> str:
+        if isinstance(err, FileNotFoundError):
+            return "Requested resource was not found"
+        if isinstance(err, FileExistsError):
+            return "Requested resource already exists"
+        if isinstance(err, (ValueError, KeyError, IndexError)):
+            return "Invalid request"
+        return public_message
+
     if public_message == "Request failed" and status < 500:
         operational_message = _operational_runtime_message(exc)
         if operational_message:
             error_message = operational_message
-        elif isinstance(exc, _SAFE_EXC_TYPES):
-            detail = str(exc).strip().split("\n", 1)[0]
-            if detail:
-                error_message = detail[:240]
+        else:
+            error_message = _default_public_message(exc)
     payload = {"success": False, "error": error_message}
     if hint:
         payload["hint"] = hint


### PR DESCRIPTION
## Summary
- stop returning exception-derived text from default API error responses
- keep fixed public error messages for known 4xx categories and explicit caller-provided messages
- replace macOS-incompatible entrypoint sed usage with a portable config rewrite

## Tests
- python3 -m py_compile web/app.py
- pytest tests/test_api_error_sanitization.py tests/test_web_route_smoke.py
- pytest tests/test_entrypoint_bootstrap.py::test_entrypoint_bootstrap_is_safe_under_parallel_first_run tests/test_api_error_sanitization.py -q
- pytest